### PR TITLE
Extend status signal with severity information

### DIFF
--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -73,8 +73,8 @@ class MainWindow(QMainWindow):
         self.ui.action_generate_data.triggered.connect(self.start_data_generation)
         self.ui.action_generate_add.triggered.connect(self.start_all_generation)
         
-        self.market_facade.status_info.connect(self.status_bar.post_message)
-        self.market_view.status_info.connect(self.status_bar.post_message)
+        self.market_facade.status_info.connect(self.status_bar.handle_status)
+        self.market_view.status_info.connect(self.status_bar.handle_status)
         
         #self.ui.action_tool.triggered.connect(self.open_about_ui)
 

--- a/src/ui/market.py
+++ b/src/ui/market.py
@@ -16,7 +16,7 @@ class Market(BaseUi):
 
     pdf_display_storage_path_changed = Signal(str) # Signal for storage path changes
     pdf_display_data_changed = Signal(object) # Signal for data changes, e.g., box updates
-    status_info = Signal(str)  # Signal for status updates
+    status_info = Signal(str, str)  # Signal for status updates
 
     def __init__(self, parent=None):
         super().__init__(parent)

--- a/src/ui/pdf_display.py
+++ b/src/ui/pdf_display.py
@@ -318,7 +318,7 @@ class PdfDisplay(BaseUi): # Inherit from your base UI class (QWidget or QMainWin
     exit_requested = Signal()
     storage_path_changed = Signal(str) # Signal for storage path changes
     data_changed = Signal(object) # Signal for data changes, e.g., box updates
-    status_info = Signal(str) # Signal for status updates
+    status_info = Signal(str, str)  # Signal for status updates
 
     def __init__(self, parent=None, *, state: PdfDisplayConfig | None = None, json_path: str | None = None):
         super().__init__(parent)
@@ -480,7 +480,7 @@ class PdfDisplay(BaseUi): # Inherit from your base UI class (QWidget or QMainWin
     def add_single_box(self):
         """Adds a new single box to the scene and list."""
         if not self.pdf_item:
-            self.status_info.emit("Bitte laden Sie zuerst eine PDF-Datei.")
+            self.status_info.emit("WARNING", "Bitte laden Sie zuerst eine PDF-Datei.")
             QMessageBox.warning(self, "Aktion nicht möglich", "Bitte laden Sie zuerst eine PDF-Datei.")
             return
         view_rect = self.ui.graphicsView.mapToScene(self.ui.graphicsView.viewport().rect()).boundingRect()
@@ -617,8 +617,8 @@ class PdfDisplay(BaseUi): # Inherit from your base UI class (QWidget or QMainWin
                 
                 pdf_display_config = self._state_to_dict()
                 pdf_display_config.save(fileName)
-                self.storage_path_changed.emit(fileName)                
-                self.status_info.emit(f"Konfiguration gespeichert: {fileName}")
+                self.storage_path_changed.emit(fileName)
+                self.status_info.emit("INFO", f"Konfiguration gespeichert: {fileName}")
                 QMessageBox.information(self, "Erfolg", f"Konfiguration erfolgreich gespeichert:\n{fileName}")
             except IOError as e:
                 QMessageBox.critical(self, "Fehler", f"Fehler beim Speichern der Datei:\n{e}")
@@ -631,7 +631,7 @@ class PdfDisplay(BaseUi): # Inherit from your base UI class (QWidget or QMainWin
         try:
             config = self._state_to_dict()
             self.data_changed.emit(config)  # Emit data changed signal           
-            self.status_info.emit(f"Konfiguration gespeichert")
+            self.status_info.emit("INFO", "Konfiguration gespeichert")
         except IOError as e:
             QMessageBox.critical(self, "Fehler", f"Fehler beim Speichern der Datei:\n{e}")
         except json.JSONDecodeError as e:
@@ -645,7 +645,7 @@ class PdfDisplay(BaseUi): # Inherit from your base UI class (QWidget or QMainWin
         if fileName:
             try:
                 config = PdfDisplayConfig(fileName)
-                self.status_info.emit(f"Konfiguration geladen: {fileName}")
+                self.status_info.emit("INFO", f"Konfiguration geladen: {fileName}")
             except FileNotFoundError:
                  QMessageBox.critical(self, "Fehler", f"Datei nicht gefunden:\n{fileName}")
                  return

--- a/src/ui/status_bar.py
+++ b/src/ui/status_bar.py
@@ -87,18 +87,29 @@ class StatusBar(QStatusBar):
         if not self._message_timer.isActive():
             self._show_next_message()
 
+    @Slot(str, str)
+    def handle_status(self, level: str, message: str) -> None:
+        """General entry point for status messages."""
+        level = level.lower()
+        if level == "warning":
+            self.post_warning(message)
+        elif level == "error":
+            self.post_error(message)
+        else:
+            self.post_message(message)
+
     @Slot(str)
-    def post_message(self, message: str):
+    def post_message(self, message: str) -> None:
         """Adds an informational message to the queue."""
         self._enqueue_message(message, "info")
 
     @Slot(str)
-    def post_warning(self, message: str):
+    def post_warning(self, message: str) -> None:
         """Adds a warning message to the queue."""
         self._enqueue_message(message, "warning")
 
     @Slot(str)
-    def post_error(self, message: str):
+    def post_error(self, message: str) -> None:
         """Adds an error message to the queue."""
         self._enqueue_message(message, "error")
 


### PR DESCRIPTION
## Summary
- extend `status_info` signal to include a level argument
- update UI components and status bar to handle the level
- emit detailed status messages in PDF display and market facade

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685bad651514832284b93994fb700741