### PR TITLE
Add Mermaid architecture diagrams

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,12 @@ Weitere Beispiele und Testskripte liegen im Verzeichnis `examples` bzw. `test_co
 - **Observer (Signal/Slot)**: Durch die Qt-Signale werden Statusmeldungen und Daten zwischen Komponenten ausgetauscht (z. B. in `DataManager.data_loaded`).
 - **Template Method**: Die Klassen in `generator/` erben von `DataGenerator` und implementieren jeweils ihre spezifische `generate` Methode.
 - **Abstraktion/Adapter**: In `display/` sind Schnittstellen für Fortschrittsbalken und Ausgaben definiert, wodurch sowohl Konsolen- als auch GUI-Varianten genutzt werden können.
+## Architekturdiagramme
+
+- [UML Klassendiagramm](architecture/uml_class_diagram.md)
+- [Abhängigkeitsdiagramm](architecture/dependency_diagram.md)
+- [Architektur-Klassendiagramm](architecture/architecture_class_diagram.md)
+
 
 ## Tests
 

--- a/architecture/architecture_class_diagram.md
+++ b/architecture/architecture_class_diagram.md
@@ -1,0 +1,29 @@
+# Architektur Klassendiagramm
+
+```mermaid
+classDiagram
+    class MarketFacade {
+        +load_local_market_project()
+        +load_local_market_export()
+        +create_pdf_data()
+        +create_market_data()
+    }
+    class DataManager {
+        +load()
+        +get_seller_as_list()
+        +get_main_number_as_list()
+    }
+    class FileGenerator {
+        +generate()
+    }
+    class FleatMarket {
+        +load_sellers()
+        +load_main_numbers()
+    }
+    MarketFacade --> DataManager : verwendet
+    MarketFacade --> FleatMarket : erstellt
+    MarketFacade --> FileGenerator : nutzt
+    FileGenerator --> FleatMarket : liest Daten
+    DataManager --> SellerDataClass
+    DataManager --> MainNumberDataClass
+```

--- a/architecture/dependency_diagram.md
+++ b/architecture/dependency_diagram.md
@@ -1,0 +1,18 @@
+# Abhängigkeitsdiagramm
+
+```mermaid
+graph TD
+    Main --> Args
+    Main --> MarketFacade
+    MarketFacade --> DataManager
+    MarketFacade --> FileGenerator
+    DataManager --> Objects
+    FileGenerator --> Generators
+    Generators --> PriceListGenerator
+    Generators --> SellerDataGenerator
+    Generators --> StatisticDataGenerator
+    Generators --> ReceiveInfoPdfGenerator
+    Main --> Display
+    Display --> ProgressBar
+    Display --> Output
+```

--- a/architecture/uml_class_diagram.md
+++ b/architecture/uml_class_diagram.md
@@ -1,0 +1,31 @@
+# UML Klassendiagramm
+
+```mermaid
+classDiagram
+    class Main {
+        +main()
+    }
+    class MarketFacade
+    class DataManager
+    class BaseData
+    class FileGenerator
+    class PriceListGenerator
+    class SellerDataGenerator
+    class StatisticDataGenerator
+    class ReceiveInfoPdfGenerator
+    class FleatMarket
+    class SellerDataClass
+    class MainNumberDataClass
+
+    Main --> MarketFacade
+    MarketFacade --> DataManager
+    MarketFacade --> FileGenerator
+    MarketFacade --> FleatMarket
+    DataManager --|> BaseData
+    DataManager --> SellerDataClass
+    DataManager --> MainNumberDataClass
+    FileGenerator --> PriceListGenerator
+    FileGenerator --> SellerDataGenerator
+    FileGenerator --> StatisticDataGenerator
+    FileGenerator --> ReceiveInfoPdfGenerator
+```


### PR DESCRIPTION
## Summary
- add UML class, dependency and architecture diagrams in Mermaid format
- reference these diagrams from the README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'PySide6')*

------
https://chatgpt.com/codex/tasks/task_e_685be41972f883228d944198c9cd4812