### PR TITLE
Add non-commercial license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,23 @@
+MIT License (Non-Commercial)
+
+Copyright (c) 2025 NoName
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software **for non-commercial purposes only**, including without
+limitation the rights to use, copy, modify, merge, publish and distribute
+copies of the Software, subject to the following conditions:
+
+Commercial use of this Software requires prior written consent from the
+copyright holder.
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -80,6 +80,25 @@ src/
 
 Weitere Beispiele und Testskripte liegen im Verzeichnis `examples` bzw. `test_code`.
 
+## Qt-Artefakte erzeugen
+
+Mit dem Skript `util/generate_qt_artefacts.py` lassen sich aus den mit Qt
+Designer erstellten `.ui`-Dateien sowie aus der Ressourcenbeschreibung
+`resources.qrc` die benötigten Python-Module erzeugen. Ein typischer Aufruf ist
+
+```bash
+python util/generate_qt_artefacts.py --all
+```
+
+Damit werden alle UI-Dateien aus `src/ui/design` nach `src/ui/generated`
+konvertiert und gleichzeitig die Ressourcendatei `resources_rc.py` erstellt.
+Weitere Optionen können über `-h` angezeigt werden.
+
+Für den späteren Bau einer ausführbaren Datei mit *auto-py-to-exe* existiert die
+Konfigurationsdatei `autopy_build_config.json` (im Repository noch unter dem
+Tippfehlernamen `auotpi_build_config.json`). Sie speichert die PyInstaller-
+Einstellungen, die von dem Tool eingelesen werden können.
+
 ## Wichtige Programmtechniken und Muster
 
 - **Singleton**: Über `SingletonMeta` wird z. B. `MarketFacade` als Singleton umgesetzt, sodass es nur eine Instanz in der Anwendung gibt.


### PR DESCRIPTION
## Summary
- change license so usage is limited to non-commercial projects unless permission is granted
- previous docs describing Qt artifact generation remain unchanged

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'PySide6')*


------
https://chatgpt.com/codex/tasks/task_e_685f0db5858c8322b335f7aff1008635