### PR TITLE
Show stamm numbers in table

### DIFF
--- a/src/data/data_manager.py
+++ b/src/data/data_manager.py
@@ -158,6 +158,42 @@ class DataManager(QObject, BaseData):
         """
         return [self.convert_seller_to_dict(seller) for seller in self.get_seller_as_list()]
 
+    def get_article_count(self, stnr_id: str) -> int:
+        """Return the number of articles for the given ``stnr`` table.
+
+        Parameters
+        ----------
+        stnr_id:
+            Either just the numeric id or the table name (e.g. ``"1"`` or ``"stnr1"``).
+
+        Returns
+        -------
+        int
+            Count of articles contained in the table. Returns ``0`` if the table
+            does not exist.
+        """
+        tables = self.get_main_number_tables()
+        key = stnr_id if stnr_id.startswith("stnr") else f"stnr{stnr_id}"
+        table = tables.get(key)
+        if not table:
+            return 0
+        return len(getattr(table, "data", []))
+
+    def get_article_sum(self, stnr_id: str) -> float:
+        """Return the total price of all articles for the given ``stnr`` table."""
+        tables = self.get_main_number_tables()
+        key = stnr_id if stnr_id.startswith("stnr") else f"stnr{stnr_id}"
+        table = tables.get(key)
+        if not table:
+            return 0.0
+        total = 0.0
+        for article in getattr(table, "data", []):
+            try:
+                total += float(article.preis)
+            except (ValueError, TypeError):
+                continue
+        return round(total, 2)
+
     def get_aggregated_users_data(self) -> List[dict]:
         """
         Returns aggregated seller data as a list of dictionaries.

--- a/src/ui/design/user_info.ui
+++ b/src/ui/design/user_info.ui
@@ -149,10 +149,23 @@ QGroupBox::title { subcontrol-origin: margin; subcontrol-position: top left; pad
        </widget>
       </item>
       <item row="6" column="1">
-       <widget class="QLabel" name="valueIDs">
-        <property name="text">
-         <string/>
+       <widget class="QTableWidget" name="tableIDs">
+        <property name="columnCount">
+         <number>3</number>
         </property>
+        <property name="editTriggers">
+         <set>QAbstractItemView.NoEditTriggers</set>
+        </property>
+        <property name="horizontalHeaderLabels" stdset="0">
+         <stringlist>
+          <string>ID</string>
+          <string>Anzahl</string>
+          <string>Summe</string>
+         </stringlist>
+        </property>
+        <column/>
+        <column/>
+        <column/>
        </widget>
       </item>
      </layout>

--- a/src/ui/generated/user_info_ui.py
+++ b/src/ui/generated/user_info_ui.py
@@ -17,7 +17,7 @@ from PySide6.QtGui import (QBrush, QColor, QConicalGradient, QCursor,
     QPalette, QPixmap, QRadialGradient, QTransform)
 from PySide6.QtWidgets import (QApplication, QCheckBox, QFormLayout, QGroupBox,
     QHBoxLayout, QLabel, QListWidget, QListWidgetItem,
-    QSizePolicy, QVBoxLayout, QWidget)
+    QSizePolicy, QTableWidget, QAbstractItemView, QVBoxLayout, QWidget)
 
 class Ui_MainWindowWidget(object):
     def setupUi(self, MainWindowWidget):
@@ -121,10 +121,14 @@ class Ui_MainWindowWidget(object):
 
         self.formLayoutDetails.setWidget(6, QFormLayout.ItemRole.LabelRole, self.labelIDs)
 
-        self.valueIDs = QLabel(self.groupBoxDetails)
-        self.valueIDs.setObjectName(u"valueIDs")
+        self.tableIDs = QTableWidget(self.groupBoxDetails)
+        if (self.tableIDs.columnCount() < 3):
+            self.tableIDs.setColumnCount(3)
+        self.tableIDs.setObjectName(u"tableIDs")
+        self.tableIDs.setEditTriggers(QAbstractItemView.EditTrigger.NoEditTriggers)
+        self.tableIDs.setColumnCount(3)
 
-        self.formLayoutDetails.setWidget(6, QFormLayout.ItemRole.FieldRole, self.valueIDs)
+        self.formLayoutDetails.setWidget(6, QFormLayout.ItemRole.FieldRole, self.tableIDs)
 
 
         self.horizontalLayout.addWidget(self.groupBoxDetails)
@@ -157,6 +161,9 @@ class Ui_MainWindowWidget(object):
         self.labelUpdatedAt.setText(QCoreApplication.translate("MainWindowWidget", u"Updated At:", None))
         self.valueUpdatedAt.setText("")
         self.labelIDs.setText(QCoreApplication.translate("MainWindowWidget", u"IDs:", None))
-        self.valueIDs.setText("")
+        self.tableIDs.setProperty(u"horizontalHeaderLabels", [
+            QCoreApplication.translate("MainWindowWidget", u"ID", None),
+            QCoreApplication.translate("MainWindowWidget", u"Anzahl", None),
+            QCoreApplication.translate("MainWindowWidget", u"Summe", None)])
     # retranslateUi
 

--- a/src/ui/user_info.py
+++ b/src/ui/user_info.py
@@ -1,3 +1,4 @@
+from PySide6.QtWidgets import QTableWidgetItem
 from .base_ui import BaseUi
 from .generated import UserInfoUi
 
@@ -59,7 +60,8 @@ class UserInfo(BaseUi):
         self.ui.valueEmail.setText("")
         self.ui.valueCreatedAt.setText("")
         self.ui.valueUpdatedAt.setText("")
-        self.ui.valueIDs.setText("")
+        self.ui.tableIDs.clearContents()
+        self.ui.tableIDs.setRowCount(0)
 
     def display_user_details(self, index):
         """Aktualisiert die Detailfelder mit den Daten des ausgewählten Benutzers."""
@@ -73,8 +75,15 @@ class UserInfo(BaseUi):
         self.ui.valueCreatedAt.setText(user.get("created_at", ""))
         self.ui.valueUpdatedAt.setText(user.get("updated_at", ""))
         if self.ui.checkboxUnique.isChecked():
-            # Aggregierter Modus: Alle IDs, kommasepariert
             ids = user.get("ids", [])
-            self.ui.valueIDs.setText(", ".join(ids))
         else:
-            self.ui.valueIDs.setText(user.get("id", ""))
+            ids = [user.get("id", "")]
+
+        dm = self.market_widget().data_manager_ref
+        self.ui.tableIDs.setRowCount(len(ids))
+        for row, id_ in enumerate(ids):
+            count = dm.get_article_count(id_) if dm else 0
+            total = dm.get_article_sum(id_) if dm else 0.0
+            self.ui.tableIDs.setItem(row, 0, QTableWidgetItem(str(id_)))
+            self.ui.tableIDs.setItem(row, 1, QTableWidgetItem(str(count)))
+            self.ui.tableIDs.setItem(row, 2, QTableWidgetItem(f"{total:.2f}"))


### PR DESCRIPTION
## Summary
- swap the ID text in *UserInfo* view for a read-only table
- list article count and price sum per stamm number
- provide helper methods in `DataManager`

## Testing
- `python -m py_compile src/ui/user_info.py src/ui/generated/user_info_ui.py src/data/data_manager.py`
- `pytest -q` *(fails: ImportError: libEGL.so.1)*

------
https://chatgpt.com/codex/tasks/task_e_685fb748e21c8322985770c9de5c976d