### PR TITLE
Implement loading markets from MySQL

### DIFF
--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -140,7 +140,7 @@ class MainWindow(QMainWindow):
             if market_loader_info["mode"] == "json":
                 ret = self.market_facade.load_local_market_porject(self.market_view,market_loader_info["path"])
             elif market_loader_info["mode"] == "mysql":
-                pass
+                ret = self.market_facade.load_online_market(self.market_view, market_loader_info)
             else:
                 #QMessageBox.critical(self, "Error", "Invalid market loader mode selected.")
                 return


### PR DESCRIPTION
## Summary
- enable loading online markets via MySQL in `MainWindow`
- implement `MarketFacade.load_online_market` using `MySQLInterface` and `AdvancedDBManager`

## Testing
- `python -m py_compile src/data/market_facade.py src/ui/main_window.py`

------
https://chatgpt.com/codex/tasks/task_e_685f0dda37d88322b7950c684e99a201