### PR TITLE
Expand architecture docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,9 +108,134 @@ Einstellungen, die von dem Tool eingelesen werden können.
 - **Abstraktion/Adapter**: In `display/` sind Schnittstellen für Fortschrittsbalken und Ausgaben definiert, wodurch sowohl Konsolen- als auch GUI-Varianten genutzt werden können.
 ## Architekturdiagramme
 
-- [UML Klassendiagramm](architecture/uml_class_diagram.md)
-- [Abhängigkeitsdiagramm](architecture/dependency_diagram.md)
-- [Architektur-Klassendiagramm](architecture/architecture_class_diagram.md)
+Die folgenden Mermaid-Diagramme veranschaulichen den Aufbau der Anwendung. Die
+entsprechenden Quelldateien liegen im Ordner `architecture` und sind hier direkt
+eingebunden.
+
+### UML Klassendiagramm
+
+```mermaid
+classDiagram
+    class Main {
+        +main()
+    }
+    class MainWindow
+    class MarketObserver
+    class MarketFacade
+    class MarketConfigHandler
+    class PdfDisplayConfig
+    class DataManager
+    class BaseData
+    class BasicDBConnector
+    class MySQLInterface
+    class FileGenerator
+    class PriceListGenerator
+    class SellerDataGenerator
+    class StatisticDataGenerator
+    class ReceiveInfoPdfGenerator
+    class FleatMarket
+    class SellerDataClass
+    class MainNumberDataClass
+
+    Main --> MarketFacade
+    Main --> MainWindow
+    MainWindow --> MarketObserver
+    MarketObserver --> MarketFacade
+    MarketFacade --> DataManager
+    MarketFacade --> FileGenerator
+    MarketFacade --> FleatMarket
+    MarketFacade --> MarketConfigHandler
+    MarketFacade --> PdfDisplayConfig
+    DataManager --|> BaseData
+    DataManager --> SellerDataClass
+    DataManager --> MainNumberDataClass
+    DataManager --> BasicDBConnector
+    BasicDBConnector --> MySQLInterface
+    FileGenerator --> PriceListGenerator
+    FileGenerator --> SellerDataGenerator
+    FileGenerator --> StatisticDataGenerator
+    FileGenerator --> ReceiveInfoPdfGenerator
+```
+
+### Abhängigkeitsdiagramm
+
+```mermaid
+graph TD
+    Main --> Args
+    Main --> MarketFacade
+    Main --> UI
+    UI --> MarketObserver
+    MarketObserver --> MarketFacade
+    MarketFacade --> DataManager
+    MarketFacade --> FileGenerator
+    MarketFacade --> MarketConfigHandler
+    MarketFacade --> PdfDisplayConfig
+    DataManager --> Objects
+    DataManager --> Backend
+    Backend --> MySQLInterface
+    FileGenerator --> Generators
+    Generators --> PriceListGenerator
+    Generators --> SellerDataGenerator
+    Generators --> StatisticDataGenerator
+    Generators --> ReceiveInfoPdfGenerator
+    Main --> Display
+    Display --> ProgressBar
+    Display --> Output
+```
+
+### Architektur-Klassendiagramm
+
+```mermaid
+classDiagram
+    class MarketFacade {
+        +load_local_market_project()
+        +load_local_market_export()
+        +create_pdf_data()
+        +create_market_data()
+    }
+    class MarketConfigHandler {
+        +load()
+    }
+    class PdfDisplayConfig {
+        +load()
+    }
+    class MarketObserver
+    class DataManager {
+        +load()
+        +get_seller_as_list()
+        +get_main_number_as_list()
+    }
+    class BasicDBConnector
+    class MySQLInterface
+    class FileGenerator {
+        +generate()
+    }
+    class PriceListGenerator
+    class SellerDataGenerator
+    class StatisticDataGenerator
+    class ReceiveInfoPdfGenerator
+    class FleatMarket {
+        +load_sellers()
+        +load_main_numbers()
+    }
+    class MainWindow
+    MarketFacade --> MarketConfigHandler : konfiguriert
+    MarketFacade --> PdfDisplayConfig : PDF-Layout
+    MarketFacade --> MarketObserver : informiert
+    MarketFacade --> DataManager : verwendet
+    MarketFacade --> FleatMarket : erstellt
+    MarketFacade --> FileGenerator : nutzt
+    FileGenerator --> PriceListGenerator
+    FileGenerator --> SellerDataGenerator
+    FileGenerator --> StatisticDataGenerator
+    FileGenerator --> ReceiveInfoPdfGenerator
+    FileGenerator --> FleatMarket : liest Daten
+    DataManager --> SellerDataClass
+    DataManager --> MainNumberDataClass
+    DataManager --> BasicDBConnector
+    BasicDBConnector --> MySQLInterface
+    MainWindow --> MarketFacade : benutzt
+```
 
 
 ## Tests

--- a/architecture/architecture_class_diagram.md
+++ b/architecture/architecture_class_diagram.md
@@ -1,5 +1,11 @@
 # Architektur Klassendiagramm
 
+Dieses Diagramm skizziert die wichtigsten Klassen der Anwendung und ihr
+Zusammenspiel. Über die Fassade `MarketFacade` werden Daten geladen,
+Konfigurationsdateien eingelesen und verschiedene Generatoren angestoßen. Die
+Daten selbst werden im `DataManager` verwaltet und in der Klasse `FleatMarket`
+für die Ausgabe aufbereitet.
+
 ```mermaid
 classDiagram
     class MarketFacade {
@@ -8,22 +14,46 @@ classDiagram
         +create_pdf_data()
         +create_market_data()
     }
+    class MarketConfigHandler {
+        +load()
+    }
+    class PdfDisplayConfig {
+        +load()
+    }
+    class MarketObserver
     class DataManager {
         +load()
         +get_seller_as_list()
         +get_main_number_as_list()
     }
+    class BasicDBConnector
+    class MySQLInterface
     class FileGenerator {
         +generate()
     }
+    class PriceListGenerator
+    class SellerDataGenerator
+    class StatisticDataGenerator
+    class ReceiveInfoPdfGenerator
     class FleatMarket {
         +load_sellers()
         +load_main_numbers()
     }
+    class MainWindow
+    MarketFacade --> MarketConfigHandler : konfiguriert
+    MarketFacade --> PdfDisplayConfig : PDF-Layout
+    MarketFacade --> MarketObserver : informiert
     MarketFacade --> DataManager : verwendet
     MarketFacade --> FleatMarket : erstellt
     MarketFacade --> FileGenerator : nutzt
+    FileGenerator --> PriceListGenerator
+    FileGenerator --> SellerDataGenerator
+    FileGenerator --> StatisticDataGenerator
+    FileGenerator --> ReceiveInfoPdfGenerator
     FileGenerator --> FleatMarket : liest Daten
     DataManager --> SellerDataClass
     DataManager --> MainNumberDataClass
+    DataManager --> BasicDBConnector
+    BasicDBConnector --> MySQLInterface
+    MainWindow --> MarketFacade : benutzt
 ```

--- a/architecture/dependency_diagram.md
+++ b/architecture/dependency_diagram.md
@@ -1,12 +1,24 @@
 # Abhängigkeitsdiagramm
 
+Dieses Diagramm zeigt die groben Modulabhängigkeiten der Anwendung. Der Start
+erfolgt über `main.py`, das wahlweise die Kommandozeile oder die Qt‑Oberfläche
+aufbaut. Die Fassade `MarketFacade` kapselt Datenzugriff, Konfiguration und die
+Erzeugung der Ausgabedateien.
+
 ```mermaid
 graph TD
     Main --> Args
     Main --> MarketFacade
+    Main --> UI
+    UI --> MarketObserver
+    MarketObserver --> MarketFacade
     MarketFacade --> DataManager
     MarketFacade --> FileGenerator
+    MarketFacade --> MarketConfigHandler
+    MarketFacade --> PdfDisplayConfig
     DataManager --> Objects
+    DataManager --> Backend
+    Backend --> MySQLInterface
     FileGenerator --> Generators
     Generators --> PriceListGenerator
     Generators --> SellerDataGenerator

--- a/architecture/uml_class_diagram.md
+++ b/architecture/uml_class_diagram.md
@@ -1,13 +1,23 @@
 # UML Klassendiagramm
 
+Das UML‑Diagramm bildet die zentralen Klassen des Projekts ab. Es zeigt, wie die
+GUI über `MainWindow` mit der `MarketFacade` kommuniziert und welche Generatoren
+für die Dateiausgabe verantwortlich sind.
+
 ```mermaid
 classDiagram
     class Main {
         +main()
     }
+    class MainWindow
+    class MarketObserver
     class MarketFacade
+    class MarketConfigHandler
+    class PdfDisplayConfig
     class DataManager
     class BaseData
+    class BasicDBConnector
+    class MySQLInterface
     class FileGenerator
     class PriceListGenerator
     class SellerDataGenerator
@@ -18,12 +28,19 @@ classDiagram
     class MainNumberDataClass
 
     Main --> MarketFacade
+    Main --> MainWindow
+    MainWindow --> MarketObserver
+    MarketObserver --> MarketFacade
     MarketFacade --> DataManager
     MarketFacade --> FileGenerator
     MarketFacade --> FleatMarket
+    MarketFacade --> MarketConfigHandler
+    MarketFacade --> PdfDisplayConfig
     DataManager --|> BaseData
     DataManager --> SellerDataClass
     DataManager --> MainNumberDataClass
+    DataManager --> BasicDBConnector
+    BasicDBConnector --> MySQLInterface
     FileGenerator --> PriceListGenerator
     FileGenerator --> SellerDataGenerator
     FileGenerator --> StatisticDataGenerator


### PR DESCRIPTION
## Summary
- extend mermaid diagrams with more classes and descriptions
- embed diagrams directly in the README

## Testing
- `pip install -r requirements-test.txt`
- `pytest -q` *(fails: ImportError: libEGL.so.1)*

------
https://chatgpt.com/codex/tasks/task_e_685fbf9e84608322bfea1983407bfafa