### PR TITLE
Add save/restore logic to MarketSetting

### DIFF
--- a/src/data/data_manager.py
+++ b/src/data/data_manager.py
@@ -3,10 +3,8 @@ from pathlib import Path
 from typing import Dict, List, Optional
 from copy import deepcopy
 import uuid
-from dataclasses import asdict, dataclass
+from dataclasses import asdict, dataclass, fields 
 from datetime import datetime
-
-from .singelton_meta import SingletonMeta
 from PySide6.QtCore import QObject, Signal
 
 sys.path.insert(0, Path(__file__).parent.parent.parent.parent.__str__())  # NOQA: E402 pylint: disable=[C0413]
@@ -15,7 +13,8 @@ from objects import (
     MainNumberDataClass,
     SellerDataClass,
     ArticleDataClass,
-    ChangeLogEntry)
+    ChangeLogEntry,
+    SettingsContentDataClass)
 
 
 class DataManager(QObject, BaseData):
@@ -461,6 +460,20 @@ class DataManager(QObject, BaseData):
             )
             return True
         return False
+    
+    def settings_available(self) -> bool:
+        return self.settings.is_all_empty()
+
+   
+    def set_default_settings(self, default_settings: SettingsContentDataClass):
+        """
+        Setzt die Default-Werte für die Settings (überschreibt alle Felder).
+        """
+        if not self.settings.data:
+            self.settings.data.append(default_settings)
+        else:
+            for field_ in fields(default_settings):
+                setattr(self.data[0], field_.name, getattr(default_settings, field_.name))
 
     def reset_all_changes(self) -> int:
         """Reset all logged changes and return the number of reverted entries."""

--- a/src/data/market_config_handler.py
+++ b/src/data/market_config_handler.py
@@ -12,7 +12,7 @@ from objects import SettingsContentDataClass
 
 class MarketConfigHandler(QObject, JsonHandler):
     """Manage one project‑configuration JSON and expose convenience helpers."""
-    default_signal_loaded = Signal(object)  # Signal to notify when the default configuration is loaded
+
     # --------------------------- defaults --------------------------- #
     _DEFAULT_STRUCTURE: Dict[str, Any] = {
                 "database": {"url": "","port": ""},

--- a/src/data/market_facade.py
+++ b/src/data/market_facade.py
@@ -82,6 +82,9 @@ class MarketObserver(QObject):
                 # Initialize the DataManager with the market JSON path
                 ret = self.data_manager.load(market_json_path)
                 if ret:
+                    if not self.data_manager.settings_available():
+                        default_settings = self.market_config_handler.get_default_settings()
+                        self.data_manager.set_default_settings(default_settings)
                     # Setup the FleatMarket with the loaded data
                     self.data_manager_loaded.emit(self.data_manager)
                     self.setup_data_generation()
@@ -150,7 +153,7 @@ class MarketObserver(QObject):
     def connect_signals(self, market) -> None:
         self.data_manager_loaded.connect(market.set_market_data)
         self.pdf_display_config_loaded.connect(market.set_pdf_config)
-        self.market_config_handler.default_signal_loaded.connect(market.set_default_settings)
+       
         market.pdf_display_storage_path_changed.connect(self.storage_path_changed)
 
 

--- a/src/ui/market.py
+++ b/src/ui/market.py
@@ -51,11 +51,16 @@ class Market(BaseUi):
 
         self.ui.tabWidget.currentChanged.connect(self.tab_changed)
         """Forward signals from the PDF display to this widget."""
-        if self.pdf_display:
-            self.pdf_display.storage_path_changed.connect(self.pdf_display_storage_path_changed)
-            self.pdf_display.data_changed.connect(self.pdf_display_data_changed)
-            self.pdf_display.status_info.connect(self.status_info)
-            self.pdf_display.data_changed.connect(self.data_changed)
+        
+        self.pdf_display.storage_path_changed.connect(self.pdf_display_storage_path_changed)
+        self.pdf_display.data_changed.connect(self.pdf_display_data_changed)
+        self.pdf_display.status_info.connect(self.status_info)
+        self.pdf_display.data_changed.connect(self.data_changed)
+
+        self.market_setting.data_changed.connect(self.data_changed)
+        
+
+        
 
     @Slot(int)
     def tab_changed(self, index: int):

--- a/src/ui/market_settings.py
+++ b/src/ui/market_settings.py
@@ -1,4 +1,9 @@
-from PySide6.QtCore import QDate, QDateTime
+import json
+from dataclasses import asdict
+from PySide6.QtCore import QDate, QDateTime, Signal, Slot
+from PySide6.QtWidgets import QFileDialog, QMessageBox
+from data.json_handler import JsonHandler
+from objects import SettingsContentDataClass
 
 from .base_ui import BaseUi
 from .generated import MarketSettingUi
@@ -6,6 +11,9 @@ from .generated import MarketSettingUi
 
 class MarketSetting(BaseUi):
     """Widget providing access to market configuration values."""
+
+    storage_path_changed = Signal(str)
+    status_info = Signal(str, str)
 
     def __init__(self, parent=None):
         """Create widgets and connect signals.
@@ -19,24 +27,28 @@ class MarketSetting(BaseUi):
         self.ui = MarketSettingUi()
         self.market = None
         self.default_settings = {}
+        self._config = JsonHandler()
         self.ui.setupUi(self)
         self.connect_signals()
 
     def connect_signals(self) -> None:
         """Hook up UI signal handlers."""
-        # self.ui.btnSaveSettings.clicked.connect(self.save_settings)
-        # self.ui.btnResetSettings.clicked.connect(self.reset_settings)
-        pass
+        self.ui.buttonSave.clicked.connect(self.save)
+        self.ui.buttonCancel.clicked.connect(self.restore)
 
-    def set_default_settings(self, settings: dict) -> None:
+    def set_default_settings(self, settings: SettingsContentDataClass | dict) -> None:
         """Store default configuration values.
 
         Parameters
         ----------
         settings:
-            Dictionary containing the default settings.
+            ``SettingsContentDataClass`` instance or a plain dictionary
+            containing the default settings.
         """
-        self.default_settings = settings
+        if isinstance(settings, dict):
+            self.default_settings = SettingsContentDataClass(**settings)
+        else:
+            self.default_settings = settings
 
     def setup_views(self, market_widget):
         """Initialise the view for the given ``market_widget``.
@@ -54,43 +66,97 @@ class MarketSetting(BaseUi):
         settings = self.market_widget().get_settings()
 
         if settings.is_all_empty():
-            settings = self.default_settings
+            settings_obj = self.default_settings
         else:
-            settings = settings.data[0]
+            settings_obj = settings.data[0]
 
-        max_stammnummern = settings.max_stammnummern
-        max_artikel = settings.max_artikel
-        datum_counter = settings.datum_counter
-        flohmarkt_nr = settings.flohmarkt_nr
-        psw_laenge = settings.psw_laenge
-        verkaufer_liste = settings.verkaufer_liste
-        datum_flohmarkt = settings.datum_flohmarkt
-        max_user_ids = settings.max_user_ids
-        tabellen_prefix = settings.tabellen_prefix
+        self._apply_state_dataclass(settings_obj)
 
-        self.ui.spinMaxStammnummer.setValue(int(max_stammnummern) if max_stammnummern.isdigit() else 0)
-        self.ui.spinMaxArtikel.setValue(int(max_artikel) if max_artikel.isdigit() else 0)
-        self.ui.dateTimeEditFlohmarktCountDown.setDateTime(QDateTime.fromString(datum_counter))
-        self.ui.spinFlohmarktNummer.setValue(int(flohmarkt_nr) if flohmarkt_nr.isdigit() else 0)
-        self.ui.spinMaxIdPerUser.setValue(int(max_user_ids) if max_user_ids.isdigit() else 0)
-        self.ui.spinPwLength.setValue(int(psw_laenge) if psw_laenge.isdigit() else 0)
-        self.ui.lineEditTabellePrefix.setText(tabellen_prefix)
-        self.ui.lineEditTabelleVerkaeufer.setText(verkaufer_liste)
-        self.ui.dateTimeEditFlohmarkt.setDate(QDate.fromString(datum_flohmarkt))
+    # ------------------------------------------------------------------
+    # Persistence helpers similar to PdfDisplay
+    # ------------------------------------------------------------------
+    def export_state(self) -> SettingsContentDataClass:
+        """Return the current UI state as dataclass."""
+        return self._state_to_dataclass()
 
-    def save_settings(self) -> None:
-        """Persist the currently shown settings."""
-        settings = {
-            "setting1": self.ui.lineEditSetting1.text(),
-            "setting2": self.ui.lineEditSetting2.text(),
-        }
-        self.market_widget().save_settings(settings)
-        self.load_settings()
+    def import_state(self, state: SettingsContentDataClass) -> None:
+        """Apply the given state to the UI."""
+        self._apply_state_dataclass(state)
 
-    def reset_settings(self) -> None:
-        """Reset settings to their defaults."""
-        self.market_widget().reset_settings()
-        self.load_settings()
+    def _state_to_dataclass(self) -> SettingsContentDataClass:
+        return SettingsContentDataClass(
+            max_stammnummern=str(self.ui.spinMaxStammnummer.value()),
+            max_artikel=str(self.ui.spinMaxArtikel.value()),
+            datum_counter=self.ui.dateTimeEditFlohmarktCountDown.dateTime().toString("yyyy-MM-dd HH:mm:ss"),
+            flohmarkt_nr=str(self.ui.spinFlohmarktNummer.value()),
+            psw_laenge=str(self.ui.spinPwLength.value()),
+            tabellen_prefix=self.ui.lineEditTabellePrefix.text(),
+            verkaufer_liste=self.ui.lineEditTabelleVerkaeufer.text(),
+            max_user_ids=str(self.ui.spinMaxIdPerUser.value()),
+            datum_flohmarkt=self.ui.dateTimeEditFlohmarkt.date().toString("yyyy-MM-dd"),
+        )
+
+    def _apply_state_dataclass(self, state: SettingsContentDataClass) -> None:
+        self.ui.spinMaxStammnummer.setValue(int(str(state.max_stammnummern)) if str(state.max_stammnummern).isdigit() else 0)
+        self.ui.spinMaxArtikel.setValue(int(str(state.max_artikel)) if str(state.max_artikel).isdigit() else 0)
+        self.ui.dateTimeEditFlohmarktCountDown.setDateTime(
+            QDateTime.fromString(state.datum_counter, "yyyy-MM-dd HH:mm:ss")
+        )
+        self.ui.spinFlohmarktNummer.setValue(int(str(state.flohmarkt_nr)) if str(state.flohmarkt_nr).isdigit() else 0)
+        self.ui.spinMaxIdPerUser.setValue(int(str(state.max_user_ids)) if str(state.max_user_ids).isdigit() else 0)
+        self.ui.spinPwLength.setValue(int(str(state.psw_laenge)) if str(state.psw_laenge).isdigit() else 0)
+        self.ui.lineEditTabellePrefix.setText(state.tabellen_prefix)
+        self.ui.lineEditTabelleVerkaeufer.setText(state.verkaufer_liste)
+        self.ui.dateTimeEditFlohmarkt.setDate(QDate.fromString(state.datum_flohmarkt))
+
+    # --- Save/Load ----------------------------------------------------
+    @Slot()
+    def save_as(self) -> None:
+        """Save settings to a new JSON file."""
+        file_name, _ = QFileDialog.getSaveFileName(self, "Einstellungen speichern", "", "JSON (*.json)")
+        if file_name:
+            try:
+                data = asdict(self.export_state())
+                with open(file_name, "w", encoding="utf-8") as fh:
+                    json.dump(data, fh, indent=4, ensure_ascii=False)
+                self._config.set_path_or_url(file_name)
+                self._config.json_data = data
+                self.storage_path_changed.emit(file_name)
+                self.status_info.emit("INFO", f"Einstellungen gespeichert: {file_name}")
+            except IOError as e:
+                self.status_info.emit("ERROR", f"Fehler beim Speichern der Datei:\n{e}")
+                QMessageBox.critical(self, "Fehler", f"Fehler beim Speichern der Datei:\n{e}")
+
+    @Slot()
+    def save(self) -> None:
+        """Save settings using the current storage path."""
+        path = self._config.get_storage_full_path()
+        if path:
+            try:
+                self._config.json_data = asdict(self.export_state())
+                self._config.save(path)
+                self.status_info.emit("INFO", "Einstellungen gespeichert")
+            except IOError as e:
+                QMessageBox.critical(self, "Fehler", f"Fehler beim Speichern der Datei:\n{e}")
+        else:
+            self.save_as()
+
+    @Slot()
+    def restore(self) -> None:
+        """Load settings from a JSON file."""
+        file_name, _ = QFileDialog.getOpenFileName(self, "Einstellungen laden", "", "JSON (*.json)")
+        if file_name:
+            try:
+                with open(file_name, "r", encoding="utf-8") as fh:
+                    data = json.load(fh)
+                state = SettingsContentDataClass(**data)
+                self.import_state(state)
+                self._config.json_data = data
+                self._config.set_path_or_url(file_name)
+                self.storage_path_changed.emit(file_name)
+                self.status_info.emit("INFO", f"Einstellungen geladen: {file_name}")
+            except (IOError, json.JSONDecodeError) as e:
+                QMessageBox.critical(self, "Fehler", f"Fehler beim Laden der Datei:\n{e}")
 
     def market_widget(self):
         """Return the associated market widget."""

--- a/src/ui/market_settings.py
+++ b/src/ui/market_settings.py
@@ -27,7 +27,6 @@ class MarketSetting(BaseUi):
         super().__init__(parent)
         self.ui = MarketSettingUi()
         self.market = None
-        self.default_settings = {}
         self._config = JsonHandler()
         self.ui.setupUi(self)
         self.connect_signals()
@@ -45,20 +44,6 @@ class MarketSetting(BaseUi):
         self.ui.lineEditTabelleVerkaeufer.textChanged.connect(self._config_changed)
         self.ui.spinMaxIdPerUser.valueChanged.connect(self._config_changed)
         self.ui.dateTimeEditFlohmarkt.dateChanged.connect(self._config_changed)
-
-    def set_default_settings(self, settings: SettingsContentDataClass | dict) -> None:
-        """Store default configuration values.
-
-        Parameters
-        ----------
-        settings:
-            ``SettingsContentDataClass`` instance or a plain dictionary
-            containing the default settings.
-        """
-        if isinstance(settings, dict):
-            self.default_settings = SettingsContentDataClass(**settings)
-        else:
-            self.default_settings = settings
 
     def setup_views(self, market_widget):
         """Initialise the view for the given ``market_widget``.

--- a/src/ui/pdf_display.py
+++ b/src/ui/pdf_display.py
@@ -650,12 +650,12 @@ class PdfDisplay(BaseUi): # Inherit from your base UI class (QWidget or QMainWin
                 QMessageBox.critical(self, "Fehler", f"Fehler beim Erstellen der JSON-Daten:\n{e}")
         else: 
             self.save_as_state()
+
     @Slot()
     def restore_state(self):
         self._apply_state_dict(self._config)
+        self._config_changed()
         
-
-
     @Slot()
     def load_state(self):
         """Loads state from a JSON file."""

--- a/src/ui/stack_widget.py
+++ b/src/ui/stack_widget.py
@@ -2,11 +2,6 @@ from PySide6.QtCore import Qt, Slot
 from PySide6.QtWidgets import QStackedWidget, QWidget
 
 
-
-
-
-
-
 class StackWidget(QStackedWidget):
     """QStackedWidget extension that keeps track of navigation history."""
 


### PR DESCRIPTION
## Summary
- bring MarketSetting feature parity with PdfDisplay
- implement export/import and save/load helpers
- wire up save/cancel buttons
- improve handling of default settings dataclass

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6862f7c2b4f08322bbef8b9798563184