### PR TITLE
Handle empty seller stammnummer

### DIFF
--- a/src/ui/data_view.py
+++ b/src/ui/data_view.py
@@ -62,7 +62,11 @@ class DataView(BaseUi):
         self.ui.treeUsers.clear()
         users_list = self.market_widget().get_aggregated_user()
         for email, user in users_list.items():
-            user_text = f'{user["info"].vorname} {user["info"].nachname})'
+            info = user["info"]
+            name = f"{info.vorname} {info.nachname}".strip()
+            if DataManager.seller_is_empty(info):
+                name = "<Leer>"
+            user_text = name
             user_item = QTreeWidgetItem([user_text])
             # Füge als untergeordnete Elemente die zugehörigen MainNumber-Tabellen hinzu.
             for main_number in user["stamms"]:
@@ -88,7 +92,10 @@ class DataView(BaseUi):
         self.listUsers.clear()
         flat_users = self.market_widget().get_seller()
         for index, seller in enumerate(flat_users, start=1):
-            text = f'{index}. {seller.vorname} {seller.nachname}'
+            name = f"{seller.vorname} {seller.nachname}".strip()
+            if DataManager.seller_is_empty(seller):
+                name = "<Leer>"
+            text = f"{index}. {name}"
             item = QListWidgetItem(text)
             item.setData(Qt.UserRole, seller)
             self.listUsers.addItem(item)
@@ -136,8 +143,10 @@ class DataView(BaseUi):
             user_text = item.text(0)
             users_list = self.market_widget().get_aggregated_user()
             for user in users_list.values():
-                #info_text = f'{user["info"].vorname} {user["info"].nachname} ({user["info"].email})'
-                info_text = f'{user["info"].vorname} {user["info"].nachname}'
+                info = user["info"]
+                info_text = f"{info.vorname} {info.nachname}".strip()
+                if DataManager.seller_is_empty(info):
+                    info_text = "<Leer>"
                 if info_text == user_text:
                     for main_number in user["stamms"]:
                         entries.extend(main_number.data)

--- a/src/ui/user_info.py
+++ b/src/ui/user_info.py
@@ -40,13 +40,14 @@ class UserInfo(BaseUi):
             self.current_user_list = self.aggregated_users_data
             for user in self.current_user_list:
                 count_ids = len(user.get("ids", []))
-
-                text = f"{user.get('vorname', '')} {user.get('nachname', '')} ({count_ids})"
+                name = f"{user.get('vorname', '')} {user.get('nachname', '')}".strip()
+                text = f"{name} ({count_ids})"
                 self.ui.listWidgetUsers.addItem(text)
         else:
             self.current_user_list = self.users_data
             for idx, user in enumerate(self.current_user_list):
-                text = f"{idx+1}: {user.get('vorname', '')} {user.get('nachname', '')}"
+                name = f"{user.get('vorname', '')} {user.get('nachname', '')}".strip()
+                text = f"{idx+1}: {name}"
                 self.ui.listWidgetUsers.addItem(text)
         if self.ui.listWidgetUsers.count() > 0:
             self.ui.listWidgetUsers.setCurrentRow(0)

--- a/tests/test_dataset_empty.json
+++ b/tests/test_dataset_empty.json
@@ -1,0 +1,15 @@
+[
+  {"type": "header", "version": "1", "comment": ""},
+  {"type": "database", "name": "test"},
+  {"type": "table", "name": "stnr1", "database": "test", "data": [
+    {"artikelnummer": "1", "beschreibung": "Item 1", "groesse": "", "preis": "10"}
+  ]},
+  {"type": "table", "name": "stnr2", "database": "test", "data": [
+    {"artikelnummer": "1", "beschreibung": "Item 2", "groesse": "", "preis": "20"}
+  ]},
+  {"type": "table", "name": "verkaeufer", "database": "test", "data": [
+    {"id": "1", "vorname": "A", "nachname": "B", "telefon": "", "email": "a@b.c", "passwort": "", "created_at": "", "updated_at": ""},
+    {"id": "2", "vorname": "", "nachname": "", "telefon": "", "email": "", "passwort": "", "created_at": "", "updated_at": ""}
+  ]},
+  {"type": "table", "name": "einstellungen", "database": "test", "data": []}
+]

--- a/tests/test_empty_seller_aggregation.py
+++ b/tests/test_empty_seller_aggregation.py
@@ -1,0 +1,30 @@
+import json
+from pathlib import Path
+import sys
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / 'src'))
+
+pytest.importorskip('PySide6')
+
+from data.data_manager import DataManager
+
+DATASET = Path(__file__).parent / 'test_dataset_empty.json'
+
+
+def test_empty_seller_grouping():
+    data = json.loads(DATASET.read_text())
+    dm = DataManager(data)
+    aggregated = dm.get_aggregated_users()
+    assert '<LEER>' in aggregated
+    empty_group = aggregated['<LEER>']
+    assert '2' in empty_group['ids']
+    stnr_names = [tbl.name for tbl in empty_group['stamms']]
+    assert 'stnr2' in stnr_names
+
+    # representation helpers
+    agg_list = dm.get_aggregated_users_data()
+    assert any(u["vorname"] == "<Leer>" for u in agg_list)
+    flat_list = dm.get_users_data()
+    assert any(u["id"] == "2" and u["vorname"] == "<Leer>" for u in flat_list)


### PR DESCRIPTION
## Summary
- treat sellers without any information as `<LEER>`
- show `<Leer>` label in DataView and UserInfo lists
- assign orphaned `stnr` tables to the `<LEER>` group
- extend tests for empty seller handling

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68668f7c028483229341f59047ddaf40