### PR TITLE
Add initial project save folder logic

### DIFF
--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -213,7 +213,12 @@ class MainWindow(QMainWindow):
 
     @Slot()
     def save_project(self):
-        """Save current project to a selected directory."""
+        """Save current project."
+        if self.market_facade.is_project(self.market_view):
+            project_dir = self.market_facade.get_project_dir(self.market_view)
+            if project_dir:
+                self.market_facade.save_project(self.market_view, project_dir)
+                return
         chosen_dir = QFileDialog.getExistingDirectory(self, "Projekt speichern")
         if chosen_dir:
             self.market_facade.save_project(self.market_view, chosen_dir)

--- a/tests/test_save_project.py
+++ b/tests/test_save_project.py
@@ -36,6 +36,8 @@ def test_save_project(tmp_path):
     assert (tmp_path / 'project.json').is_file()
     pdf = Path(__file__).resolve().parents[1] / 'src' / 'resource' / 'default_data' / 'Abholung_Template.pdf'
     assert (tmp_path / pdf.name).is_file()
+    assert obs.project_exists()
+    assert obs.get_project_dir() == str(tmp_path)
 
 
 def test_facade_save_project(tmp_path):
@@ -53,3 +55,5 @@ def test_facade_save_project(tmp_path):
     assert (tmp_path / 'project.json').is_file()
     pdf = Path(__file__).resolve().parents[1] / 'src' / 'resource' / 'default_data' / 'Abholung_Template.pdf'
     assert (tmp_path / pdf.name).is_file()
+    assert facade.is_project(market)
+    assert facade.get_project_dir(market) == str(tmp_path)


### PR DESCRIPTION
## Summary
- keep track of project directory in `MarketFacade`
- update saving logic to remember directory and mark project existing
- adjust project loading to record the folder path
- expose `get_project_dir` and use it in the GUI
- extend tests for the new behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687180b344a483228ab7a2d568397417