### PR TITLE
Add secondary progress bar widget

### DIFF
--- a/src/ui/design/output_window.ui
+++ b/src/ui/design/output_window.ui
@@ -34,8 +34,8 @@ QGroupBox::title { subcontrol-origin: margin; subcontrol-position: top left; pad
      </property>
     </widget>
    </item>
-   <item>
-    <widget class="QProgressBar" name="progressBar">
+    <item>
+     <widget class="QProgressBar" name="progressBar">
      <property name="toolTip">
       <string>Zeigt den Fortschritt der Ausgabe an</string>
      </property>
@@ -55,9 +55,31 @@ QGroupBox::title { subcontrol-origin: margin; subcontrol-position: top left; pad
       <set>Qt::AlignCenter</set>
      </property>
     </widget>
-   </item>
-  </layout>
- </widget>
- <resources/>
- <connections/>
-</ui>
+    </item>
+    <item>
+     <widget class="QProgressBar" name="progressBar_2">
+      <property name="toolTip">
+       <string>Zeigt den Fortschritt der Ausgabe an (zweite Leiste)</string>
+      </property>
+      <property name="value">
+       <number>0</number>
+      </property>
+      <property name="minimum">
+       <number>0</number>
+      </property>
+      <property name="maximum">
+       <number>100</number>
+      </property>
+      <property name="textVisible">
+       <bool>true</bool>
+      </property>
+      <property name="alignment">
+       <set>Qt::AlignCenter</set>
+      </property>
+     </widget>
+    </item>
+   </layout>
+  </widget>
+  <resources/>
+  <connections/>
+ </ui>

--- a/src/ui/generated/output_window_ui.py
+++ b/src/ui/generated/output_window_ui.py
@@ -41,6 +41,16 @@ class Ui_OutputWindow(object):
 
         self.verticalLayout.addWidget(self.progressBar)
 
+        self.progressBar_2 = QProgressBar(OutputWindow)
+        self.progressBar_2.setObjectName(u"progressBar_2")
+        self.progressBar_2.setValue(0)
+        self.progressBar_2.setMinimum(0)
+        self.progressBar_2.setMaximum(100)
+        self.progressBar_2.setTextVisible(True)
+        self.progressBar_2.setAlignment(Qt.AlignCenter)
+
+        self.verticalLayout.addWidget(self.progressBar_2)
+
 
         self.retranslateUi(OutputWindow)
 
@@ -60,6 +70,9 @@ class Ui_OutputWindow(object):
         self.logOutputTextEdit.setPlaceholderText(QCoreApplication.translate("OutputWindow", u"Warte auf Ausgabe...", None))
 #if QT_CONFIG(tooltip)
         self.progressBar.setToolTip(QCoreApplication.translate("OutputWindow", u"Zeigt den Fortschritt der Ausgabe an", None))
+#endif // QT_CONFIG(tooltip)
+#if QT_CONFIG(tooltip)
+        self.progressBar_2.setToolTip(QCoreApplication.translate("OutputWindow", u"Zeigt den Fortschritt der Ausgabe an (zweite Leiste)", None))
 #endif // QT_CONFIG(tooltip)
     # retranslateUi
 


### PR DESCRIPTION
## Summary
- add a second progress bar below the existing one in the output window
- regenerate Qt artefacts to include new widget

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests' and SyntaxError in main_window.py)*

------
https://chatgpt.com/codex/tasks/task_e_6872494dec68832297207acfc9c122c2