### PR TITLE
Implement progress interface for OutputWindow

### DIFF
--- a/src/data/json_handler.py
+++ b/src/data/json_handler.py
@@ -425,6 +425,7 @@ class JsonHandler():
             return False
         return self.json_data == other.get_data()
     
+    @staticmethod
     def split_path_and_filename(path_str: str) -> tuple[str, str]:
         """
         Teilt einen String (URL oder lokaler Pfad) in

--- a/src/data/market_facade.py
+++ b/src/data/market_facade.py
@@ -11,6 +11,7 @@ from objects import FleatMarket
 from typing import List, Dict, Any, Union
 from pathlib import Path
 import tempfile
+import shutil
 from backend import MySQLInterface
 from backend.advance_db_connector import AdvancedDBManager
 
@@ -526,6 +527,10 @@ class MarketFacade(QObject, metaclass=SingletonMeta):
             observer.market_config_handler.set_full_market_path(str(market_file))
             observer.market_config_handler.set_full_pdf_coordinates_config_path(str(pdf_file))
             observer.market_config_handler.save_to(str(project_file))
+
+            pdf_path = observer.pdf_display_config_loader.get_full_pdf_path()
+            if pdf_path and Path(pdf_path).is_file():
+                shutil.copy(pdf_path, target_dir / Path(pdf_path).name)
 
             # remember location and mark project as existing
             observer.set_project_dir(dir_path)

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -213,7 +213,7 @@ class MainWindow(QMainWindow):
 
     @Slot()
     def save_project(self):
-        """Save current project."
+        """Save current project."""
         if self.market_facade.is_project(self.market_view):
             project_dir = self.market_facade.get_project_dir(self.market_view)
             if project_dir:

--- a/src/ui/output_window.py
+++ b/src/ui/output_window.py
@@ -1,10 +1,19 @@
-from PySide6.QtWidgets import QDialog
+from PySide6.QtWidgets import QDialog, QProgressBar, QWidget
+from PySide6.QtCore import QTimer
+from abc import ABCMeta
+
+from display import OutputInterfaceAbstraction, BasicProgressTracker
+
+
+class _WidgetABCMeta(type(QWidget), ABCMeta):
+    """Combine Qt's widget metaclass with :class:`ABCMeta`."""
+    pass
 
 from .base_ui import BaseUi
 from .generated import OutputWindowUi
 
 
-class OutputWindow(BaseUi):
+class OutputWindow(BaseUi, OutputInterfaceAbstraction, metaclass=_WidgetABCMeta):
     """Simple dialog used to present generation results."""
 
     def __init__(self, parent: QDialog | None = None) -> None:
@@ -18,3 +27,49 @@ class OutputWindow(BaseUi):
         super().__init__(parent)
         self.ui = OutputWindowUi()
         self.ui.setupUi(self)
+        self.progress_bar_1: QProgressBar = self.ui.progressBar
+        self.progress_bar_2: QProgressBar = self.ui.progressBar_2
+        self._tracker1: BasicProgressTracker | None = None
+        self._tracker2: BasicProgressTracker | None = None
+        self._timer: QTimer | None = None
+
+    # ---------------------------------------------------------------
+    # OutputInterfaceAbstraction implementation
+    # ---------------------------------------------------------------
+    def write_message(self, message: str) -> None:
+        """Append ``message`` to the log output widget."""
+        self.ui.logOutputTextEdit.appendPlainText(message)
+
+    # ---------------------------------------------------------------
+    # Progress handling
+    # ---------------------------------------------------------------
+    def _ensure_timer(self) -> None:
+        """Create and start the update timer if necessary."""
+        if self._timer is None:
+            self._timer = QTimer(self)
+            self._timer.setInterval(100)
+            self._timer.timeout.connect(self._update_bars)
+            self._timer.start()
+
+    def _update_bars(self) -> None:
+        """Update progress bars from assigned trackers."""
+        if self._tracker1 is not None:
+            self.progress_bar_1.setValue(self._tracker1.percentage)
+        if self._tracker2 is not None:
+            self.progress_bar_2.setValue(self._tracker2.percentage)
+        if (
+            (self._tracker1 is None or self._tracker1.percentage >= 100)
+            and (self._tracker2 is None or self._tracker2.percentage >= 100)
+            and self._timer is not None
+        ):
+            self._timer.stop()
+
+    def set_primary_tracker(self, tracker: BasicProgressTracker) -> None:
+        """Assign ``tracker`` to the first progress bar and start updates."""
+        self._tracker1 = tracker
+        self._ensure_timer()
+
+    def set_secondary_tracker(self, tracker: BasicProgressTracker) -> None:
+        """Assign ``tracker`` to the second progress bar and start updates."""
+        self._tracker2 = tracker
+        self._ensure_timer()


### PR DESCRIPTION
## Summary
- implement `OutputWindow` as a Qt widget that also acts as `OutputInterfaceAbstraction`
- track two progress bars via optional timers
- fix incomplete docstring in `MainWindow`
- make `JsonHandler.split_path_and_filename` a static method
- copy template PDF when `MarketFacade.save_project` runs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68724ac2a0e0832282887154ecfba279