### PR TITLE
Refactor PDF generator settings

### DIFF
--- a/src/data/market_facade.py
+++ b/src/data/market_facade.py
@@ -238,14 +238,23 @@ class MarketObserver(QObject):
         except AttributeError:
             pass
 
+        pdf_settings = self.market_config_handler.get_pdf_generation_data()
         self.file_generator = FileGenerator(
             self.fm,
             output_interface=window,
             progress_tracker=tracker,
+            output_path=pdf_settings.get("output_path", "output"),
+            pdf_template_path_input=pdf_settings.get(
+                "pdf_template",
+                pdf_settings.get("pdf_template_path_input", "template/template.pdf"),
+            ),
+            pdf_output_file_name=pdf_settings.get(
+                "pdf_output_file_name",
+                pdf_settings.get("pdf_name", "Abholbestaetigungen.pdf"),
+            ),
+            pdf_coordinates=pdf_settings.get("coordinates"),
         )
-        self.file_generator.create_pdf_data(
-            self.market_config_handler.get_pdf_generation_data()
-        )
+        self.file_generator.create_pdf_data()
         self.status_info.emit(
             "ERROR" if tracker.has_error else "INFO",
             "PDF Daten generiert" if not tracker.has_error else "PDF Fehler"
@@ -263,10 +272,12 @@ class MarketObserver(QObject):
         except AttributeError:
             pass
 
+        pdf_settings = self.market_config_handler.get_pdf_generation_data()
         self.file_generator = FileGenerator(
             self.fm,
             output_interface=window,
             progress_tracker=tracker,
+            output_path=pdf_settings.get("output_path", "output"),
         )
         self.file_generator.create_seller_data()
         self.status_info.emit(
@@ -286,14 +297,23 @@ class MarketObserver(QObject):
         except AttributeError:
             pass
 
+        pdf_settings = self.market_config_handler.get_pdf_generation_data()
         self.file_generator = FileGenerator(
             self.fm,
             output_interface=window,
             progress_tracker=tracker,
+            output_path=pdf_settings.get("output_path", "output"),
+            pdf_template_path_input=pdf_settings.get(
+                "pdf_template",
+                pdf_settings.get("pdf_template_path_input", "template/template.pdf"),
+            ),
+            pdf_output_file_name=pdf_settings.get(
+                "pdf_output_file_name",
+                pdf_settings.get("pdf_name", "Abholbestaetigungen.pdf"),
+            ),
+            pdf_coordinates=pdf_settings.get("coordinates"),
         )
-        self.file_generator.create_all(
-            self.market_config_handler.get_pdf_generation_data()
-        )
+        self.file_generator.create_all()
         self.status_info.emit(
             "ERROR" if tracker.has_error else "INFO",
             "Alle Daten erstellt" if not tracker.has_error else "Fehler bei Erstellung"

--- a/src/generator/receive_info_pdf_generator.py
+++ b/src/generator/receive_info_pdf_generator.py
@@ -83,6 +83,41 @@ class ReceiveInfoPdfGenerator(DataGenerator):  # noqa: D101 – see module docst
         self._entries_per_page = len(self._coords)
         self._output_pdf = (self.path / opath).with_suffix(".pdf")
 
+        # --------------------------------------------------------------
+        # Expose constructor parameters via typed properties
+        # --------------------------------------------------------------
+
+    # ---------------------------- properties ----------------------------
+    @property
+    def template_path(self) -> Optional[Path]:
+        """Path to the template PDF or ``None`` if not set."""
+        return self._template_path
+
+    @template_path.setter
+    def template_path(self, value: str | Path | None) -> None:
+        self._template_path = Path(value) if value else None
+
+    @property
+    def coordinates(self) -> List[CoordinatesConfig]:
+        """List of coordinate configurations used for PDF generation."""
+        return self._coords
+
+    @coordinates.setter
+    def coordinates(self, value: List[CoordinatesConfig]) -> None:
+        if not value:
+            raise ValueError("coordinates list cannot be empty")
+        self._coords = value
+        self._entries_per_page = len(self._coords)
+
+    @property
+    def output_pdf(self) -> Path:
+        """Full path of the generated PDF file."""
+        return self._output_pdf
+
+    @output_pdf.setter
+    def output_pdf(self, value: str | Path) -> None:
+        self._output_pdf = Path(value)
+
     # ------------------------------------------------------------------
     # Data collection helpers
     # ------------------------------------------------------------------

--- a/src/ui/output_window.py
+++ b/src/ui/output_window.py
@@ -1,13 +1,21 @@
 from PySide6.QtCore import QTimer, Slot
+from PySide6.QtWidgets import QWidget
 from PySide6.QtWidgets import QDialog
 
 from display import OutputInterfaceAbstraction, BasicProgressTracker
 
 from .base_ui import BaseUi
 from .generated import OutputWindowUi
+from abc import ABCMeta
 
 
-class OutputWindow(BaseUi, OutputInterfaceAbstraction):
+class _WidgetABCMeta(type(QWidget), ABCMeta):
+    """Combine Qt's widget metaclass with :class:`ABCMeta`."""
+    pass
+
+
+
+class OutputWindow(BaseUi, OutputInterfaceAbstraction, metaclass=_WidgetABCMeta):
     """Simple dialog used to present generation results."""
 
     def __init__(self, parent: QDialog | None = None) -> None:


### PR DESCRIPTION
## Summary
- expose template, coordinates and output PDF through new setters in `ReceiveInfoPdfGenerator`
- pass PDF generation options directly to `FileGenerator` from `MarketFacade`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68762c6a6e2483228431e92380b46628