### PR TITLE
Extend PDF output configuration

### DIFF
--- a/src/data/market_facade.py
+++ b/src/data/market_facade.py
@@ -204,6 +204,8 @@ class MarketObserver(QObject):
         # update display config
         self.pdf_display_config_loader.load(str(cfg_dst))
         self.pdf_display_config_loader.set_full_pdf_path(str(pdf_dst))
+        self.pdf_display_config_loader.set_output_path(str(project_dir))
+        self.pdf_display_config_loader.set_output_name("Abholbestätigung.pdf")
         self.pdf_display_config_loader.save(str(cfg_dst))
 
         self.pdf_display_config_loaded.emit(self.pdf_display_config_loader)

--- a/src/data/pdf_display_config.py
+++ b/src/data/pdf_display_config.py
@@ -65,6 +65,8 @@ class PdfDisplayConfig(QObject, JsonHandler):
     _TEMPLATE: Dict[str, Any] = {
         "pdf_path": "",
         "pdf_name": "",
+        "output_path": "",
+        "output_name": "",
         "boxPairs": [],
         "singleBoxes": [],
     }
@@ -107,6 +109,33 @@ class PdfDisplayConfig(QObject, JsonHandler):
     def set_pdf_name(self, value: str) -> None:
         """Set the PDF file name."""
         self.set_key_value(["pdf_name"], str(value))
+
+    # ------------------------------------------------------------------
+    # Output path / output name
+    # ------------------------------------------------------------------
+    def get_output_path(self) -> str:
+        """Return the configured output directory path."""
+        return str(self.get_key_value(["output_path"]) or "")
+
+    def set_output_path(self, value: str) -> None:
+        self.set_key_value(["output_path"], str(value))
+
+    def get_output_name(self) -> str:
+        """Return the configured output file name."""
+        return str(self.get_key_value(["output_name"]) or "")
+
+    def set_output_name(self, value: str) -> None:
+        self.set_key_value(["output_name"], str(value))
+
+    def get_full_output_path(self) -> str:
+        """Return the absolute output path composed of directory and file name."""
+        path = self.get_output_path()
+        return self.ensure_trailing_sep(path) + self.get_output_name()
+
+    def set_full_output_path(self, value: str) -> None:
+        file = Path(value)
+        self.set_key_value(["output_path"], str(file.parent))
+        self.set_key_value(["output_name"], file.name)
 
     def get_full_pdf_path(self) -> str:
         """Return the absolute PDF path composed of directory and file name."""
@@ -242,6 +271,3 @@ class PdfDisplayConfig(QObject, JsonHandler):
             return True
         else:
             return False 
-    
-
-    

--- a/src/resource/default_data/pdf_display_config.json
+++ b/src/resource/default_data/pdf_display_config.json
@@ -1,6 +1,8 @@
 {
     "pdf_path": "D:\\Projekte\\Python\\FlohmarktManager",
     "pdf_name": "Abholung_Template.pdf",
+    "output_path": "",
+    "output_name": "Abholbestätigung.pdf",
     "boxPairs": [
         {
             "id": 1,

--- a/src/ui/design/pdf_display.ui
+++ b/src/ui/design/pdf_display.ui
@@ -333,22 +333,23 @@ QGroupBox::title { subcontrol-origin: margin; subcontrol-position: top left; pad
            <item row="0" column="0">
             <widget class="QLabel" name="labelOutputPath">
              <property name="text">
-              <string>Output Pfad:</string>
+              <string>Output Datei:</string>
              </property>
             </widget>
            </item>
            <item row="0" column="1">
-            <widget class="QLineEdit" name="lineEditOutputPath"/>
-           </item>
-           <item row="1" column="0">
-            <widget class="QLabel" name="labelOutputName">
-             <property name="text">
-              <string>Dateiname:</string>
-             </property>
-            </widget>
-           </item>
-           <item row="1" column="1">
-            <widget class="QLineEdit" name="lineEditOutputName"/>
+            <layout class="QHBoxLayout" name="layoutOutput">
+             <item>
+              <widget class="QLineEdit" name="lineEditOutputPath"/>
+             </item>
+             <item>
+              <widget class="QPushButton" name="btnSaveOutputPath">
+               <property name="text">
+                <string>Speichern</string>
+               </property>
+              </widget>
+             </item>
+            </layout>
            </item>
           </layout>
          </item>

--- a/src/ui/design/pdf_display.ui
+++ b/src/ui/design/pdf_display.ui
@@ -314,20 +314,44 @@ QGroupBox::title { subcontrol-origin: margin; subcontrol-position: top left; pad
               <attribute name="buttonGroup">
                <string notr="true">buttonGroup</string>
               </attribute>
-             </widget>
-            </item>
-            <item>
-             <widget class="QPushButton" name="btnSaveAsConfig">
+            </widget>
+           </item>
+           <item>
+            <widget class="QPushButton" name="btnSaveAsConfig">
               <property name="text">
                <string>Speichern unter</string>
               </property>
               <attribute name="buttonGroup">
                <string notr="true">buttonGroup</string>
               </attribute>
-             </widget>
-            </item>
-           </layout>
-          </item>
+            </widget>
+           </item>
+          </layout>
+         </item>
+         <item>
+          <layout class="QFormLayout" name="formLayoutOutput">
+           <item row="0" column="0">
+            <widget class="QLabel" name="labelOutputPath">
+             <property name="text">
+              <string>Output Pfad:</string>
+             </property>
+            </widget>
+           </item>
+           <item row="0" column="1">
+            <widget class="QLineEdit" name="lineEditOutputPath"/>
+           </item>
+           <item row="1" column="0">
+            <widget class="QLabel" name="labelOutputName">
+             <property name="text">
+              <string>Dateiname:</string>
+             </property>
+            </widget>
+           </item>
+           <item row="1" column="1">
+            <widget class="QLineEdit" name="lineEditOutputName"/>
+           </item>
+          </layout>
+         </item>
          </layout>
         </widget>
        </item>

--- a/src/ui/generated/pdf_display_ui.py
+++ b/src/ui/generated/pdf_display_ui.py
@@ -243,20 +243,20 @@ class Ui_PdfDisplayView(object):
 
         self.formLayoutOutput.setWidget(0, QFormLayout.ItemRole.LabelRole, self.labelOutputPath)
 
+        self.layoutOutput = QHBoxLayout()
+        self.layoutOutput.setObjectName(u"layoutOutput")
         self.lineEditOutputPath = QLineEdit(self.groupBox_3)
         self.lineEditOutputPath.setObjectName(u"lineEditOutputPath")
 
-        self.formLayoutOutput.setWidget(0, QFormLayout.ItemRole.FieldRole, self.lineEditOutputPath)
+        self.layoutOutput.addWidget(self.lineEditOutputPath)
 
-        self.labelOutputName = QLabel(self.groupBox_3)
-        self.labelOutputName.setObjectName(u"labelOutputName")
+        self.btnSaveOutputPath = QPushButton(self.groupBox_3)
+        self.btnSaveOutputPath.setObjectName(u"btnSaveOutputPath")
 
-        self.formLayoutOutput.setWidget(1, QFormLayout.ItemRole.LabelRole, self.labelOutputName)
+        self.layoutOutput.addWidget(self.btnSaveOutputPath)
 
-        self.lineEditOutputName = QLineEdit(self.groupBox_3)
-        self.lineEditOutputName.setObjectName(u"lineEditOutputName")
 
-        self.formLayoutOutput.setWidget(1, QFormLayout.ItemRole.FieldRole, self.lineEditOutputName)
+        self.formLayoutOutput.setLayout(0, QFormLayout.ItemRole.FieldRole, self.layoutOutput)
 
 
         self.verticalLayout_3.addLayout(self.formLayoutOutput)
@@ -332,8 +332,8 @@ class Ui_PdfDisplayView(object):
         self.btnLoadConfig.setText(QCoreApplication.translate("PdfDisplayView", u"Laden", None))
         self.btnSaveConfig.setText(QCoreApplication.translate("PdfDisplayView", u"Speichern", None))
         self.btnSaveAsConfig.setText(QCoreApplication.translate("PdfDisplayView", u"Speichern unter", None))
-        self.labelOutputPath.setText(QCoreApplication.translate("PdfDisplayView", u"Output Pfad:", None))
-        self.labelOutputName.setText(QCoreApplication.translate("PdfDisplayView", u"Dateiname:", None))
+        self.labelOutputPath.setText(QCoreApplication.translate("PdfDisplayView", u"Output Datei:", None))
+        self.btnSaveOutputPath.setText(QCoreApplication.translate("PdfDisplayView", u"Speichern", None))
         self.btnAddSingleBox.setText(QCoreApplication.translate("PdfDisplayView", u"Datum hinzuf\u00fcgen", None))
         self.btnAddBoxPair.setText(QCoreApplication.translate("PdfDisplayView", u"StNr. hinzuf\u00fcgen", None))
         self.btnRemoveBoxPair.setText(QCoreApplication.translate("PdfDisplayView", u"Entfernen", None))

--- a/src/ui/generated/pdf_display_ui.py
+++ b/src/ui/generated/pdf_display_ui.py
@@ -3,7 +3,7 @@
 ################################################################################
 ## Form generated from reading UI file 'pdf_display.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.8.2
+## Created by: Qt User Interface Compiler version 6.9.1
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################
@@ -124,7 +124,7 @@ class Ui_PdfDisplayView(object):
         self.label_name = QLabel(self.groupBox)
         self.label_name.setObjectName(u"label_name")
 
-        self.formLayout_1.setWidget(0, QFormLayout.LabelRole, self.label_name)
+        self.formLayout_1.setWidget(0, QFormLayout.ItemRole.LabelRole, self.label_name)
 
         self.lineEditName = QLineEdit(self.groupBox)
         self.lineEditName.setObjectName(u"lineEditName")
@@ -134,19 +134,19 @@ class Ui_PdfDisplayView(object):
         sizePolicy2.setHeightForWidth(self.lineEditName.sizePolicy().hasHeightForWidth())
         self.lineEditName.setSizePolicy(sizePolicy2)
 
-        self.formLayout_1.setWidget(0, QFormLayout.FieldRole, self.lineEditName)
+        self.formLayout_1.setWidget(0, QFormLayout.ItemRole.FieldRole, self.lineEditName)
 
         self.label_stammnummer = QLabel(self.groupBox)
         self.label_stammnummer.setObjectName(u"label_stammnummer")
 
-        self.formLayout_1.setWidget(1, QFormLayout.LabelRole, self.label_stammnummer)
+        self.formLayout_1.setWidget(1, QFormLayout.ItemRole.LabelRole, self.label_stammnummer)
 
         self.lineEditStammnummer = QLineEdit(self.groupBox)
         self.lineEditStammnummer.setObjectName(u"lineEditStammnummer")
         sizePolicy2.setHeightForWidth(self.lineEditStammnummer.sizePolicy().hasHeightForWidth())
         self.lineEditStammnummer.setSizePolicy(sizePolicy2)
 
-        self.formLayout_1.setWidget(1, QFormLayout.FieldRole, self.lineEditStammnummer)
+        self.formLayout_1.setWidget(1, QFormLayout.ItemRole.FieldRole, self.lineEditStammnummer)
 
 
         self.verticalLayout_sidebar.addWidget(self.groupBox)
@@ -159,50 +159,50 @@ class Ui_PdfDisplayView(object):
         self.labelX = QLabel(self.groupBoxProperties)
         self.labelX.setObjectName(u"labelX")
 
-        self.formLayoutProperties.setWidget(0, QFormLayout.LabelRole, self.labelX)
+        self.formLayoutProperties.setWidget(0, QFormLayout.ItemRole.LabelRole, self.labelX)
 
         self.lineEditX = QLineEdit(self.groupBoxProperties)
         self.lineEditX.setObjectName(u"lineEditX")
         sizePolicy2.setHeightForWidth(self.lineEditX.sizePolicy().hasHeightForWidth())
         self.lineEditX.setSizePolicy(sizePolicy2)
 
-        self.formLayoutProperties.setWidget(0, QFormLayout.FieldRole, self.lineEditX)
+        self.formLayoutProperties.setWidget(0, QFormLayout.ItemRole.FieldRole, self.lineEditX)
 
         self.labelY = QLabel(self.groupBoxProperties)
         self.labelY.setObjectName(u"labelY")
 
-        self.formLayoutProperties.setWidget(1, QFormLayout.LabelRole, self.labelY)
+        self.formLayoutProperties.setWidget(1, QFormLayout.ItemRole.LabelRole, self.labelY)
 
         self.lineEditY = QLineEdit(self.groupBoxProperties)
         self.lineEditY.setObjectName(u"lineEditY")
         sizePolicy2.setHeightForWidth(self.lineEditY.sizePolicy().hasHeightForWidth())
         self.lineEditY.setSizePolicy(sizePolicy2)
 
-        self.formLayoutProperties.setWidget(1, QFormLayout.FieldRole, self.lineEditY)
+        self.formLayoutProperties.setWidget(1, QFormLayout.ItemRole.FieldRole, self.lineEditY)
 
         self.labelWidth = QLabel(self.groupBoxProperties)
         self.labelWidth.setObjectName(u"labelWidth")
 
-        self.formLayoutProperties.setWidget(2, QFormLayout.LabelRole, self.labelWidth)
+        self.formLayoutProperties.setWidget(2, QFormLayout.ItemRole.LabelRole, self.labelWidth)
 
         self.lineEditWidth = QLineEdit(self.groupBoxProperties)
         self.lineEditWidth.setObjectName(u"lineEditWidth")
         sizePolicy2.setHeightForWidth(self.lineEditWidth.sizePolicy().hasHeightForWidth())
         self.lineEditWidth.setSizePolicy(sizePolicy2)
 
-        self.formLayoutProperties.setWidget(2, QFormLayout.FieldRole, self.lineEditWidth)
+        self.formLayoutProperties.setWidget(2, QFormLayout.ItemRole.FieldRole, self.lineEditWidth)
 
         self.labelHeight = QLabel(self.groupBoxProperties)
         self.labelHeight.setObjectName(u"labelHeight")
 
-        self.formLayoutProperties.setWidget(3, QFormLayout.LabelRole, self.labelHeight)
+        self.formLayoutProperties.setWidget(3, QFormLayout.ItemRole.LabelRole, self.labelHeight)
 
         self.lineEditHeight = QLineEdit(self.groupBoxProperties)
         self.lineEditHeight.setObjectName(u"lineEditHeight")
         sizePolicy2.setHeightForWidth(self.lineEditHeight.sizePolicy().hasHeightForWidth())
         self.lineEditHeight.setSizePolicy(sizePolicy2)
 
-        self.formLayoutProperties.setWidget(3, QFormLayout.FieldRole, self.lineEditHeight)
+        self.formLayoutProperties.setWidget(3, QFormLayout.ItemRole.FieldRole, self.lineEditHeight)
 
 
         self.verticalLayout_sidebar.addWidget(self.groupBoxProperties)
@@ -235,6 +235,31 @@ class Ui_PdfDisplayView(object):
 
 
         self.verticalLayout_3.addLayout(self.horizontalLayout)
+
+        self.formLayoutOutput = QFormLayout()
+        self.formLayoutOutput.setObjectName(u"formLayoutOutput")
+        self.labelOutputPath = QLabel(self.groupBox_3)
+        self.labelOutputPath.setObjectName(u"labelOutputPath")
+
+        self.formLayoutOutput.setWidget(0, QFormLayout.ItemRole.LabelRole, self.labelOutputPath)
+
+        self.lineEditOutputPath = QLineEdit(self.groupBox_3)
+        self.lineEditOutputPath.setObjectName(u"lineEditOutputPath")
+
+        self.formLayoutOutput.setWidget(0, QFormLayout.ItemRole.FieldRole, self.lineEditOutputPath)
+
+        self.labelOutputName = QLabel(self.groupBox_3)
+        self.labelOutputName.setObjectName(u"labelOutputName")
+
+        self.formLayoutOutput.setWidget(1, QFormLayout.ItemRole.LabelRole, self.labelOutputName)
+
+        self.lineEditOutputName = QLineEdit(self.groupBox_3)
+        self.lineEditOutputName.setObjectName(u"lineEditOutputName")
+
+        self.formLayoutOutput.setWidget(1, QFormLayout.ItemRole.FieldRole, self.lineEditOutputName)
+
+
+        self.verticalLayout_3.addLayout(self.formLayoutOutput)
 
 
         self.verticalLayout_sidebar.addWidget(self.groupBox_3)
@@ -307,6 +332,8 @@ class Ui_PdfDisplayView(object):
         self.btnLoadConfig.setText(QCoreApplication.translate("PdfDisplayView", u"Laden", None))
         self.btnSaveConfig.setText(QCoreApplication.translate("PdfDisplayView", u"Speichern", None))
         self.btnSaveAsConfig.setText(QCoreApplication.translate("PdfDisplayView", u"Speichern unter", None))
+        self.labelOutputPath.setText(QCoreApplication.translate("PdfDisplayView", u"Output Pfad:", None))
+        self.labelOutputName.setText(QCoreApplication.translate("PdfDisplayView", u"Dateiname:", None))
         self.btnAddSingleBox.setText(QCoreApplication.translate("PdfDisplayView", u"Datum hinzuf\u00fcgen", None))
         self.btnAddBoxPair.setText(QCoreApplication.translate("PdfDisplayView", u"StNr. hinzuf\u00fcgen", None))
         self.btnRemoveBoxPair.setText(QCoreApplication.translate("PdfDisplayView", u"Entfernen", None))

--- a/src/ui/pdf_display.py
+++ b/src/ui/pdf_display.py
@@ -362,6 +362,7 @@ class PdfDisplay(PersistentBaseUi):
         self.ui.btnSaveAsConfig.clicked.connect(self.save_as_state)
         self.ui.btnSaveConfig.clicked.connect(self.save_state)
         self.ui.btnLoadConfig.clicked.connect(self.load_state)
+        self.ui.btnSaveOutputPath.clicked.connect(self.save_output_path)
         
         self.scene.selectionChanged.connect(self.on_scene_selection_changed)
         self.ui.listBoxPairs.itemSelectionChanged.connect(self.on_list_selection_changed)
@@ -616,6 +617,21 @@ class PdfDisplay(PersistentBaseUi):
 
         super().save_as_state()
         QMessageBox.information(self, "Erfolg", f"Konfiguration erfolgreich gespeichert:\n{self._config.get_storage_full_path()}")
+
+    @Slot()
+    def save_output_path(self):
+        """Save the output file path from the LineEdit to the config file."""
+        if not self._config:
+            return
+        self._config.set_full_output_path(self.ui.lineEditOutputPath.text())
+        storage = self._config.get_storage_full_path()
+        if storage:
+            try:
+                self._config.save(storage)
+                self.status_info.emit("INFO", f"Output-Pfad gespeichert: {storage}")
+                self._config_changed()
+            except IOError as e:
+                QMessageBox.critical(self, "Fehler", f"Speichern fehlgeschlagen:\n{e}")
    
 
     # --- UI Update Slots ---
@@ -795,8 +811,7 @@ class PdfDisplay(PersistentBaseUi):
         # Setze Metadaten via die setter-Methoden der Config
 
         config.set_full_pdf_path(self.pdfPath)
-        config.set_output_path(self.ui.lineEditOutputPath.text())
-        config.set_output_name(self.ui.lineEditOutputName.text())
+        config.set_full_output_path(self.ui.lineEditOutputPath.text())
         
 
         # Box-Paare hinzufügen
@@ -835,8 +850,7 @@ class PdfDisplay(PersistentBaseUi):
             if self._config.get_full_pdf_path():
                 self._load_pdf_from_path(self._config.get_full_pdf_path())
 
-            self.ui.lineEditOutputPath.setText(self._config.get_output_path())
-            self.ui.lineEditOutputName.setText(self._config.get_output_name())
+            self.ui.lineEditOutputPath.setText(self._config.get_full_output_path())
 
             # ---------- Box-Paare ----------
             max_pair_id = 0

--- a/src/ui/pdf_display.py
+++ b/src/ui/pdf_display.py
@@ -793,8 +793,10 @@ class PdfDisplay(PersistentBaseUi):
         
         config = PdfDisplayConfig()
         # Setze Metadaten via die setter-Methoden der Config
-        
+
         config.set_full_pdf_path(self.pdfPath)
+        config.set_output_path(self.ui.lineEditOutputPath.text())
+        config.set_output_name(self.ui.lineEditOutputName.text())
         
 
         # Box-Paare hinzufügen
@@ -821,7 +823,7 @@ class PdfDisplay(PersistentBaseUi):
         """Stellt den Zustand aus einem zuvor erzeugten PdfDisplayConfig wieder her,
         unter Nutzung der Methoden von PdfDisplayConfig."""
         
-        self._config = config 
+        self._config = config
 
         if not self._config.is_empty():
 
@@ -832,6 +834,9 @@ class PdfDisplay(PersistentBaseUi):
             # Set the config for later use
             if self._config.get_full_pdf_path():
                 self._load_pdf_from_path(self._config.get_full_pdf_path())
+
+            self.ui.lineEditOutputPath.setText(self._config.get_output_path())
+            self.ui.lineEditOutputName.setText(self._config.get_output_name())
 
             # ---------- Box-Paare ----------
             max_pair_id = 0


### PR DESCRIPTION
## Summary
- support output path and filename in PdfDisplayConfig
- show output path and filename in PDF display UI
- set default output values when loading default config
- regenerate UI code

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687677bc836c8322bd5ab786345a2f49