### PR TITLE
Fix OutputWindow output and progress logic

### DIFF
--- a/examples/output_window_example.py
+++ b/examples/output_window_example.py
@@ -1,0 +1,48 @@
+import sys
+import threading
+from pathlib import Path
+
+# Allow imports from repository root and src directory
+ROOT = Path(__file__).parent.parent
+sys.path.insert(0, str(ROOT / "src"))
+sys.path.insert(0, str(ROOT))
+
+from data.data_manager import DataManager
+from objects import FleatMarket
+from generator.file_generator import FileGenerator
+from display import BasicProgressTracker
+from ui.output_window import OutputWindow
+from PySide6.QtWidgets import QApplication
+
+
+if __name__ == "__main__":
+    # Load a small example dataset shipped with the tests
+    dataset = ROOT / "tests" / "test_dataset.json"
+    dm = DataManager(str(dataset))
+
+    # Build FleatMarket instance from the parsed data
+    market = FleatMarket()
+    market.load_sellers(dm.get_seller_as_list())
+    market.load_main_numbers(dm.get_main_number_as_list())
+
+    tracker = BasicProgressTracker()
+
+    app = QApplication(sys.argv)
+    window = OutputWindow()
+    window.set_primary_tracker(tracker)
+    window.show()
+
+    def run_generation():
+        FileGenerator(
+            market,
+            output_path="example_output",
+            pdf_template_path_input=str(
+                ROOT / "src" / "resource" / "default_data" / "Abholung_Template.pdf"
+            ),
+            output_interface=window,
+            progress_tracker=tracker,
+        ).create_all()
+
+    # Run generation in a background thread so the UI stays responsive
+    threading.Thread(target=run_generation, daemon=True).start()
+    sys.exit(app.exec())

--- a/src/ui/output_window.py
+++ b/src/ui/output_window.py
@@ -2,7 +2,11 @@ from PySide6.QtCore import QTimer, Slot
 from PySide6.QtWidgets import QWidget
 from PySide6.QtWidgets import QDialog
 
-from display import OutputInterfaceAbstraction, BasicProgressTracker
+from display import (
+    OutputInterfaceAbstraction,
+    BasicProgressTracker,
+    QtOutput,
+)
 
 from .base_ui import BaseUi
 from .generated import OutputWindowUi
@@ -30,7 +34,10 @@ class OutputWindow(BaseUi, OutputInterfaceAbstraction, metaclass=_WidgetABCMeta)
         self.ui = OutputWindowUi()
         self.ui.setupUi(self)
 
-        # References to progress bars
+        # Output interface implementation for the text widget
+        self._output = QtOutput(self.ui.logOutputTextEdit)
+
+        # References to progress bars from the UI
         self.primary_bar = self.ui.progressBar
         self.secondary_bar = self.ui.progressBar_2
 
@@ -43,8 +50,8 @@ class OutputWindow(BaseUi, OutputInterfaceAbstraction, metaclass=_WidgetABCMeta)
 
     # ------------------------------------------------------------------
     def write_message(self, message: str) -> None:
-        """Append ``message`` to the output text edit."""
-        self.ui.logOutputTextEdit.appendPlainText(message)
+        """Append ``message`` to the output text widget via :class:`QtOutput`."""
+        self._output.write_message(message)
 
     # ------------------------------------------------------------------
     def _ensure_timer(self) -> None:
@@ -60,7 +67,7 @@ class OutputWindow(BaseUi, OutputInterfaceAbstraction, metaclass=_WidgetABCMeta)
         if self._primary_tracker is not None:
             self.primary_bar.setValue(self._primary_tracker.percentage)
         if self._secondary_tracker is not None:
-            self._secondary_tracker.setValue(self._secondary_tracker.percentage)
+            self.secondary_bar.setValue(self._secondary_tracker.percentage)
         if (
             (self._primary_tracker is None or self._primary_tracker.percentage >= 100)
             and (self._secondary_tracker is None or self._secondary_tracker.percentage >= 100)


### PR DESCRIPTION
## Summary
- integrate `QtOutput` into OutputWindow
- fix progress bar update bug
- keep progress bar polling via timer
- add OutputWindow example script

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687916cbb6e88322976610c130b3b4a0