### PR TITLE
Implement JSON backup on save

### DIFF
--- a/tests/test_backup.py
+++ b/tests/test_backup.py
@@ -1,0 +1,24 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / 'src'))
+
+import pytest
+pytest.importorskip('PySide6')
+
+from data.data_manager import DataManager
+
+DATASET = Path(__file__).parent / 'test_dataset.json'
+
+
+def test_backup_creation(tmp_path):
+    dm = DataManager(str(DATASET))
+    target = tmp_path / 'market.json'
+    dm.save(str(target))
+    assert target.is_file()
+    dm.save(str(target))
+    backup1 = tmp_path / 'market.json_1.backup'
+    assert backup1.is_file()
+    dm.save(str(target))
+    backup2 = tmp_path / 'market.json_2.backup'
+    assert backup2.is_file()


### PR DESCRIPTION
## Summary
- create numbered backups when saving JSON data
- ensure UI helpers store a backup before overwriting
- test that saving creates backups

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687b5376fbec832284d961113885058d