### PR TITLE
Implement fallback settings for export

### DIFF
--- a/src/data/__init__.py
+++ b/src/data/__init__.py
@@ -1,4 +1,3 @@
-
 """Convenience imports for the data layer."""
 
 from .base import Base
@@ -6,5 +5,15 @@ from .json_handler import JsonHandler
 from .base_data import BaseData
 from .data_manager import DataManager
 from .market_config_handler import MarketConfigHandler
-from .market_facade import  MarketFacade
+from .market_facade import MarketFacade
 from .pdf_display_config import PdfDisplayConfig
+
+__all__ = [
+    "Base",
+    "JsonHandler",
+    "BaseData",
+    "DataManager",
+    "MarketConfigHandler",
+    "MarketFacade",
+    "PdfDisplayConfig",
+]

--- a/src/data/default_settings.py
+++ b/src/data/default_settings.py
@@ -1,0 +1,13 @@
+from objects import SettingsContentDataClass
+
+DEFAULT_SETTINGS = SettingsContentDataClass(
+    max_stammnummern="250",
+    max_artikel="40",
+    datum_counter="2025-09-15 12:00:00",
+    flohmarkt_nr="6",
+    psw_laenge="10",
+    tabellen_prefix="str",
+    verkaufer_liste="verkeaufer",
+    max_user_ids="8",
+    datum_flohmarkt="2025-09-15",
+)


### PR DESCRIPTION
## Summary
- introduce `default_settings` module with built in fallback settings
- refactor `MarketObserver` to support applying default settings
- ask the user to create a project when importing an export and apply defaults
- expose data modules via cleaned `__init__`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687cbd3e40ac8322a45dd3109932b78f