### PR TITLE
Switch project files to .project

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Die Anwendung kann JSON-Exporte laden und in ein dauerhaftes Projekt überführe
 
 - **Export laden und umwandeln** – Über *Datei → Export öffnen…* wird eine Export-JSON geladen. Mit *Projekt → Speichern unter…* lässt sich daraus ein neues Projekt anlegen.
 - **Projekt speichern** – Beim Speichern erstellt das Programm im Projektordner
-  - `<name>.json` – die Projektdatei mit Pfaden und Einstellungen,
+  - `<name>.project` – die Projektdatei mit Pfaden und Einstellungen,
   - `pdf_display_config.json` – Layoutdaten für die PDF-Erzeugung,
   - die ursprüngliche Exportdatei.
   Außerdem erzeugt die Datengenerierung im Ausgabeverzeichnis `kundendaten.dat`, `preisliste.dat`, `versand.dat` und `Abholbestaetigungen.pdf`.

--- a/src/data/market_facade.py
+++ b/src/data/market_facade.py
@@ -336,7 +336,7 @@ class MarketObserver(QObject):
             target_dir.mkdir(parents=True, exist_ok=True)
             self.data_manager.save(str(target_dir / market_file))
             self.pdf_display_config_loader.save(str(target_dir / "pdf_display_config.json"))
-            self.market_config_handler.save_to(str(target_dir / "project.json"))
+            self.market_config_handler.save_to(str(target_dir / "project.project"))
             pdf_path = self.pdf_display_config_loader.get_full_pdf_path()
             if pdf_path and Path(pdf_path).is_file():
                 shutil.copy(pdf_path, target_dir / Path(pdf_path).name)
@@ -642,7 +642,7 @@ class MarketFacade(QObject, metaclass=SingletonMeta):
                 or "pdf_display_config.json"
             )
             project_file = target_dir / (
-                observer.market_config_handler.get_storage_file_name() or "project.json"
+                observer.market_config_handler.get_storage_file_name() or "project.project"
             )
 
             observer.data_manager.json_data = observer.data_manager.export_to_json()

--- a/src/objects/__init__.py
+++ b/src/objects/__init__.py
@@ -1,5 +1,17 @@
 from .data_class_definition import *
-from .article import Article
-from .seller import Seller
-from .main_number import MainNumber
-from .fleat_market import FleatMarket
+
+
+def __getattr__(name: str):
+    if name == "Article":
+        from .article import Article
+        return Article
+    if name == "Seller":
+        from .seller import Seller
+        return Seller
+    if name == "MainNumber":
+        from .main_number import MainNumber
+        return MainNumber
+    if name == "FleatMarket":
+        from .fleat_market import FleatMarket
+        return FleatMarket
+    raise AttributeError(name)

--- a/src/ui/market_loader_dialog.py
+++ b/src/ui/market_loader_dialog.py
@@ -37,9 +37,9 @@ class MarketLoaderDialog(QDialog):
 
     # ────────────────────────── Helferfunktionen ─────────────────────────
     def _browse_json(self) -> None:
-        """Dateiauswahl‑Dialog für JSON‑Projektdateien."""
+        """Dateiauswahl‑Dialog für Projektdateien."""
         path, _ = QFileDialog.getOpenFileName(
-            self, "JSON‑Projektdatei wählen", "", "JSON‑Dateien (*.json)"
+            self, "Projektdatei wählen", "", "Projektdateien (*.project)"
         )
         if path:
             self.ui.jsonPathEdit.setText(path)

--- a/tests/test_save_project.py
+++ b/tests/test_save_project.py
@@ -33,7 +33,7 @@ def test_save_project(tmp_path):
     assert obs.save_project(str(tmp_path))
     assert (tmp_path / 'market.json').is_file()
     assert (tmp_path / 'pdf_display_config.json').is_file()
-    assert (tmp_path / 'project.json').is_file()
+    assert (tmp_path / 'project.project').is_file()
     pdf = Path(__file__).resolve().parents[1] / 'src' / 'resource' / 'default_data' / 'Abholung_Template.pdf'
     assert (tmp_path / pdf.name).is_file()
     assert obs.project_exists()
@@ -52,7 +52,7 @@ def test_facade_save_project(tmp_path):
     assert facade.save_project(market, str(tmp_path))
     assert (tmp_path / 'market.json').is_file()
     assert (tmp_path / 'pdf_display_config.json').is_file()
-    assert (tmp_path / 'project.json').is_file()
+    assert (tmp_path / 'project.project').is_file()
     pdf = Path(__file__).resolve().parents[1] / 'src' / 'resource' / 'default_data' / 'Abholung_Template.pdf'
     assert (tmp_path / pdf.name).is_file()
     assert facade.is_project(market)


### PR DESCRIPTION
## Summary
- change saved project extension from `.json` to `.project`
- adjust project file selection in the loader dialog
- update tests and docs to reference `.project`
- provide lazy imports for objects to avoid heavy dependencies during import

## Testing
- `pip install -r requirements-test.txt`
- `pytest -q` *(fails: ImportError about `SettingsContentDataClass`)*

------
https://chatgpt.com/codex/tasks/task_e_68808f3f97ec8322aebe6a9755e32204