### PR TITLE
Update project file naming

### DIFF
--- a/src/data/market_facade.py
+++ b/src/data/market_facade.py
@@ -512,7 +512,8 @@ class MarketFacade(QObject, metaclass=SingletonMeta):
             return False, None
 
         observer.init_project(str(new_export))
-        project_file = target / "project.project"
+        project_name = Path(new_export).stem + ".project"
+        project_file = target / project_name
         try:
             observer.market_config_handler.save_to(str(project_file))
         except Exception as err:

--- a/tests/test_project_file_name.py
+++ b/tests/test_project_file_name.py
@@ -1,0 +1,37 @@
+import sys
+from pathlib import Path
+import shutil
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / 'src'))
+
+from data.market_facade import MarketFacade
+
+class DummySignal:
+    def connect(self, *args, **kwargs):
+        pass
+
+class DummyMarket:
+    def __init__(self):
+        self.pdf_display_storage_path_changed = DummySignal()
+    def set_market_data(self, *args, **kwargs):
+        pass
+    def set_pdf_config(self, *args, **kwargs):
+        pass
+
+
+def test_project_file_matches_json(tmp_path):
+    dataset = Path(__file__).parent / 'test_dataset.json'
+    export = tmp_path / 'export_data.json'
+    shutil.copy(dataset, export)
+
+    facade = MarketFacade()
+    market = DummyMarket()
+    facade.create_observer(market)
+
+    observer = facade.get_observer(market)
+    observer._ask_for_default_pdf_config = lambda: False
+
+    ret, target = facade.create_project_from_export(market, str(export), str(tmp_path))
+    assert ret is True
+    project_file = tmp_path / 'export_data.project'
+    assert project_file.is_file()


### PR DESCRIPTION
## Summary
- name `.project` file after export JSON when creating a project
- test new project naming behavior

## Testing
- `pytest tests/test_save_project.py tests/test_project_file_name.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68808fdc2be083228754d7bbdf5d4a5b