### PR TITLE
Switch market loader to '.project' files

### DIFF
--- a/src/ui/design/market_loader_dialog.ui
+++ b/src/ui/design/market_loader_dialog.ui
@@ -24,7 +24,7 @@ QGroupBox::title { subcontrol-origin: margin; subcontrol-position: top left; pad
    <item>
     <widget class="QRadioButton" name="jsonRadio">
      <property name="text">
-      <string>JSON-Projektdatei verwenden</string>
+      <string>Projektdatei verwenden</string>
      </property>
      <property name="checked">
       <bool>true</bool>

--- a/src/ui/generated/market_loader_dialog_ui.py
+++ b/src/ui/generated/market_loader_dialog_ui.py
@@ -148,7 +148,7 @@ class Ui_MarketLoaderDialog(object):
 "QPushButton:hover { background-color: #005a9e; }\n"
 "QGroupBox { border: 1px solid #cccccc; border-radius: 4px; margin-top: 6px; }\n"
 "QGroupBox::title { subcontrol-origin: margin; subcontrol-position: top left; padding: 0 6px; }", None))
-        self.jsonRadio.setText(QCoreApplication.translate("MarketLoaderDialog", u"JSON-Projektdatei verwenden", None))
+        self.jsonRadio.setText(QCoreApplication.translate("MarketLoaderDialog", u"Projektdatei verwenden", None))
         self.labelJson.setText(QCoreApplication.translate("MarketLoaderDialog", u"Projektdatei:", None))
         self.browseJsonBtn.setText(QCoreApplication.translate("MarketLoaderDialog", u"Durchsuchen \u2026", None))
         self.mysqlRadio.setText(QCoreApplication.translate("MarketLoaderDialog", u"Direkte MySQL-Verbindung", None))

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -149,7 +149,7 @@ class MainWindow(QMainWindow):
         dialog = MarketLoaderDialog(self)
         if dialog.exec() == QDialog.DialogCode.Accepted:
             market_loader_info = dialog.get_result()
-            if market_loader_info["mode"] == "json":
+            if market_loader_info["mode"] == "project":
                 ret = self.market_facade.load_local_market_porject(self.market_view,market_loader_info["path"])
             elif market_loader_info["mode"] == "mysql":
                 ret = self.market_facade.load_online_market(self.market_view, market_loader_info)

--- a/src/ui/market_loader_dialog.py
+++ b/src/ui/market_loader_dialog.py
@@ -15,7 +15,7 @@ from .generated import MarketLoaderUi
 class MarketLoaderDialog(QDialog):
     """Dialog, der zwei Lade‑Varianten bietet:
 
-    * **JSON‑Projektdatei** (Pfad auswählen)
+    * **Projektdatei** (Pfad auswählen)
     * **Direkte MySQL‑Verbindung** (Host / Port / DB / User / Passwort)
     """
 
@@ -28,7 +28,7 @@ class MarketLoaderDialog(QDialog):
 
         # ────────────────────────── Signale verbinden ─────────────────────
         self.ui.jsonRadio.toggled.connect(self._update_mode)
-        self.ui.browseJsonBtn.clicked.connect(self._browse_json)
+        self.ui.browseJsonBtn.clicked.connect(self._browse_project)
         self.ui.okBtn.clicked.connect(self.accept)
         self.ui.cancelBtn.clicked.connect(self.reject)
 
@@ -36,7 +36,7 @@ class MarketLoaderDialog(QDialog):
         self._update_mode()
 
     # ────────────────────────── Helferfunktionen ─────────────────────────
-    def _browse_json(self) -> None:
+    def _browse_project(self) -> None:
         """Dateiauswahl‑Dialog für Projektdateien."""
         path, _ = QFileDialog.getOpenFileName(
             self, "Projektdatei wählen", "", "Projektdateien (*.project)"
@@ -48,7 +48,7 @@ class MarketLoaderDialog(QDialog):
         """Aktiviert/Deaktiviert Eingabefelder je nach gewählter Option."""
         json_active = self.ui.jsonRadio.isChecked()
 
-        # JSON‑Felder
+        # Projekt-Datei Felder
         self.ui.jsonPathEdit.setEnabled(json_active)
         self.ui.browseJsonBtn.setEnabled(json_active)
 
@@ -67,7 +67,7 @@ class MarketLoaderDialog(QDialog):
         """Liest die aktuell eingegebenen Daten aus und liefert sie strukturiert."""
         if self.ui.jsonRadio.isChecked():
             return {
-                "mode": "json",
+                "mode": "project",
                 "path": self.ui.jsonPathEdit.text().strip(),
             }
         return {


### PR DESCRIPTION
## Summary
- update the MarketLoader UI to work with `.project` files
- adjust project loader mode in `MainWindow`

## Testing
- `pytest -q` *(fails: ImportError: libGL.so.1)*

------
https://chatgpt.com/codex/tasks/task_e_68809397492c8322a55aaa5089b2aacb