### PR TITLE
Fix open_file_dialog error handling

### DIFF
--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -136,6 +136,8 @@ class MainWindow(QMainWindow):
         Switches the currently displayed view in the stack to the data view.
         """
         local_json = self.open_file_dialog()
+        if local_json is None:
+            return
         self.market_facade.load_local_market_export(self.market_view, local_json)
         self.open_view("Market")
 
@@ -220,8 +222,8 @@ class MainWindow(QMainWindow):
         file_name, _ = QFileDialog.getOpenFileName(self, "Open JSON File", "", "JSON Files (*.json)")
         if file_name:
             return file_name
-        else:            
-            QMessageBox.critical(self, "Error", f"Failed to load JSON file: {e}")
+        else:
+            QMessageBox.critical(self, "Error", "Failed to load JSON file.")
             return None
 
     @Slot()


### PR DESCRIPTION
## Summary
- fix undefined variable in `open_file_dialog`
- guard against cancelled selection in `open_local_market_export`

## Testing
- `pytest -q` *(fails: ImportError: cannot import name 'QThread' from 'PySide6.QtCore')*

------
https://chatgpt.com/codex/tasks/task_e_68809c94743c8322899ffb9bc50a93ca