### PR TITLE
Add autosave before generating PDF

### DIFF
--- a/src/data/market_facade.py
+++ b/src/data/market_facade.py
@@ -7,7 +7,7 @@ from .data_manager import DataManager
 from .market_config_handler import MarketConfigHandler
 from .singelton_meta import SingletonMeta
 from .pdf_display_config import PdfDisplayConfig
-from generator import FileGenerator
+from generator.file_generator import FileGenerator
 from objects import FleatMarket, SettingsContentDataClass
 from display import BasicProgressTracker
 from typing import List, Dict, Any, Union

--- a/src/main.py
+++ b/src/main.py
@@ -16,7 +16,7 @@ from objects import MainNumberDataClass
 from objects import FleatMarket
 
 
-from generator import FileGenerator
+from generator.file_generator import FileGenerator
 from display import BasicProgressTracker as ProgressTracker
 from display import ConsoleProgressBar as ConsoleBar
 from display import ConsoleOutput as OutputIface

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -270,6 +270,7 @@ class MainWindow(QMainWindow):
         """
         Starts the PDF generation process.
         """
+        self.market_view.pdf_display.save_state()
         window = OutputWindow(self)
         window.show()
         ok = self.market_facade.create_pdf_data(self.market_view, window)
@@ -281,6 +282,7 @@ class MainWindow(QMainWindow):
         """
         Starts the generation of all data and PDF files.
         """
+        self.market_view.pdf_display.save_state()
         window = OutputWindow(self)
         window.show()
         ok = self.market_facade.create_all_data(self.market_view, window)


### PR DESCRIPTION
## Summary
- autosave PDF display config before generating data
- fix imports for `FileGenerator`

## Testing
- `pytest -q` *(fails: ImportError)*

------
https://chatgpt.com/codex/tasks/task_e_688293362af083229511a73b2523e1d0