### PR TITLE
Update PDF progress handling

### DIFF
--- a/src/data/data_manager.py
+++ b/src/data/data_manager.py
@@ -5,7 +5,21 @@ from copy import deepcopy
 import uuid
 from dataclasses import asdict, dataclass, fields
 from datetime import datetime
-from PySide6.QtCore import QObject, Signal
+try:
+    from PySide6.QtCore import QObject, Signal
+except Exception:  # pragma: no cover - optional PySide6
+    class QObject:  # type: ignore
+        pass
+
+    class Signal:  # type: ignore
+        def __init__(self, *args, **kwargs) -> None:
+            pass
+
+        def emit(self, *args, **kwargs) -> None:
+            pass
+
+        def connect(self, *_a, **_k) -> None:
+            pass
 
 sys.path.insert(0, Path(__file__).parent.parent.parent.parent.__str__())  # NOQA: E402 pylint: disable=[C0413]
 from .base_data import BaseData

--- a/src/data/market_config_handler.py
+++ b/src/data/market_config_handler.py
@@ -1,6 +1,20 @@
 import copy
 import os
-from PySide6.QtCore import QObject, Signal
+try:
+    from PySide6.QtCore import QObject, Signal
+except Exception:  # pragma: no cover - optional PySide6
+    class QObject:  # type: ignore
+        pass
+
+    class Signal:  # type: ignore
+        def __init__(self, *args, **kwargs) -> None:
+            pass
+
+        def emit(self, *args, **kwargs) -> None:
+            pass
+
+        def connect(self, *_a, **_k) -> None:
+            pass
 
 from pathlib import Path
 from typing import Any, Dict, TYPE_CHECKING, Union

--- a/src/data/market_facade.py
+++ b/src/data/market_facade.py
@@ -1,8 +1,58 @@
 
 """High level facade combining various market related components."""
 
-from PySide6.QtCore import QObject, Slot, Signal
-from PySide6.QtWidgets import QMessageBox, QFileDialog
+try:
+    from PySide6.QtCore import QObject, Slot, Signal
+    from PySide6.QtWidgets import QMessageBox, QFileDialog
+except Exception:  # pragma: no cover - optional PySide6
+    class QObject:  # type: ignore
+        pass
+
+    def Slot(*_args, **_kwargs):  # type: ignore
+        def decorator(func):
+            return func
+
+        return decorator
+
+    class Signal:  # type: ignore
+        def __init__(self, *args, **kwargs) -> None:
+            pass
+
+        def emit(self, *args, **kwargs) -> None:
+            pass
+
+        def connect(self, *_a, **_k) -> None:
+            pass
+
+    class QMessageBox:  # type: ignore
+        Question = Yes = No = 0
+
+        def setIcon(self, *_a, **_k) -> None:
+            pass
+
+        def setWindowTitle(self, *_a, **_k) -> None:
+            pass
+
+        def setText(self, *_a, **_k) -> None:
+            pass
+
+        def setStandardButtons(self, *_a, **_k) -> None:
+            pass
+
+        def setDefaultButton(self, *_a, **_k) -> None:
+            pass
+
+        def exec(self) -> int:
+            return 0
+
+    class QFileDialog:  # type: ignore
+        @staticmethod
+        def getExistingDirectory(*_a, **_k) -> str:
+            return ""
+
+        @staticmethod
+        def getSaveFileName(*_a, **_k) -> tuple[str, str]:
+            return "", ""
 from .data_manager import DataManager
 from .market_config_handler import MarketConfigHandler
 from .singelton_meta import SingletonMeta

--- a/src/data/pdf_display_config.py
+++ b/src/data/pdf_display_config.py
@@ -4,7 +4,21 @@ from __future__ import annotations
 
 import copy
 import os
-from PySide6.QtCore import QObject, Signal
+try:
+    from PySide6.QtCore import QObject, Signal
+except Exception:  # pragma: no cover - optional PySide6
+    class QObject:  # type: ignore
+        pass
+
+    class Signal:  # type: ignore
+        def __init__(self, *args, **kwargs) -> None:
+            pass
+
+        def emit(self, *args, **kwargs) -> None:
+            pass
+
+        def connect(self, *_a, **_k) -> None:
+            pass
 from dataclasses import dataclass, asdict
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Union

--- a/src/data/singelton_meta.py
+++ b/src/data/singelton_meta.py
@@ -1,5 +1,9 @@
 
-from PySide6.QtCore import QObject
+try:
+    from PySide6.QtCore import QObject
+except Exception:  # pragma: no cover - optional PySide6
+    class QObject:  # type: ignore
+        pass
 
 
 class SingletonMeta(type(QObject)):

--- a/src/display/__init__.py
+++ b/src/display/__init__.py
@@ -1,12 +1,19 @@
 
 from .output.output_interface_abstraction import OutputInterfaceAbstraction
 from .output.cosole_output import ConsoleOutput
-from .output.qt_output import QtOutput
+
+try:
+    from .output.qt_output import QtOutput
+except Exception:  # pragma: no cover - optional PySide6
+    QtOutput = None  # type: ignore
 
 from .tracker.progress_tracker_abstraction import ProgressTrackerAbstraction
 from .tracker.basic_porgress_tracker import BasicProgressTracker
 
 from .progress_bar.progress_bar_abstraction import ProgressBarAbstraction
 from .progress_bar.console_progress_bar import ConsoleProgressBar
-from .progress_bar.qt_progress_bar import QtProgressBar
+try:
+    from .progress_bar.qt_progress_bar import QtProgressBar
+except Exception:  # pragma: no cover - optional PySide6
+    QtProgressBar = None  # type: ignore
 

--- a/src/generator/file_generator.py
+++ b/src/generator/file_generator.py
@@ -10,9 +10,10 @@ from display import (
     OutputInterfaceAbstraction,                      # type: ignore
     ProgressTrackerAbstraction as _TrackerBase,      # type: ignore
 )
-from display.progress_bar.progress_bar_abstraction import (
-    ProgressBarAbstraction as _BarBase,              # type: ignore
-)
+try:
+    from display import ProgressBarAbstraction as _BarBase
+except Exception:  # pragma: no cover - optional dependency
+    _BarBase = None  # type: ignore
 
 # Sub‑generators -----------------------------------------------------------
 from data import Base


### PR DESCRIPTION
## Summary
- support optional `ProgressBarAbstraction` in `ReceiveInfoPdfGenerator`
- wire secondary tracker to output interfaces when available
- allow missing GUI dependencies by adding stubs in data modules
- guard Qt imports in `display.__init__`
- import progress bar abstraction more flexibly

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6882a7a5552c8322bbe527c8bb9f9a0a