### PR TITLE
Enable threaded file generation

### DIFF
--- a/src/data/market_facade.py
+++ b/src/data/market_facade.py
@@ -332,13 +332,13 @@ class MarketObserver(QObject):
         except AttributeError:
             pass
 
-        pdf_settings = self.market_config_handler.get_pdf_generation_data()
+        output_path = self.pdf_display_config_loader.get_output_path()
 
         self.file_generator = FileGenerator(
             self.fm,
             output_interface=window,
             progress_tracker=tracker,
-            output_path=pdf_settings.get("output_path", "output"),
+            output_path=output_path,
         )
         return self.file_generator, tracker
 
@@ -355,25 +355,23 @@ class MarketObserver(QObject):
         except AttributeError:
             pass
 
-        pdf_settings = self.market_config_handler.get_pdf_generation_data()
+        template_path = self.pdf_display_config_loader.get_full_pdf_path()
+        output_path = self.pdf_display_config_loader.get_output_path()
+        output_name = self.pdf_display_config_loader.get_output_name()
+        coordinates = self.pdf_display_config_loader.convert_json_to_coordinate_list()
         pickup_date = self.pdf_display_config_loader.get_pickup_date()
         pickup_time = self.pdf_display_config_loader.get_pickup_time()
         pickup = f"{pickup_date} {pickup_time}".strip()
         dpi = self.pdf_display_config_loader.get_dpi()
+
         self.file_generator = FileGenerator(
             self.fm,
             output_interface=window,
             progress_tracker=tracker,
-            output_path=pdf_settings.get("output_path", "output"),
-            pdf_template_path_input=pdf_settings.get(
-                "pdf_template",
-                pdf_settings.get("pdf_template_path_input", "template/template.pdf"),
-            ),
-            pdf_output_file_name=pdf_settings.get(
-                "pdf_output_file_name",
-                pdf_settings.get("pdf_name", "Abholbestaetigungen.pdf"),
-            ),
-            pdf_coordinates=pdf_settings.get("coordinates"),
+            output_path=output_path,
+            pdf_template_path_input=template_path,
+            pdf_output_file_name=output_name,
+            pdf_coordinates=coordinates,
             pdf_display_dpi=dpi,
             pickup_date=pickup,
         )

--- a/src/ui/generator_worker.py
+++ b/src/ui/generator_worker.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from PySide6.QtCore import QThread
+from generator.file_generator import FileGenerator
+
+
+class GeneratorWorker(QThread):
+    """Run a ``FileGenerator`` method in a separate thread."""
+
+    def __init__(self, generator: FileGenerator, method: str) -> None:
+        super().__init__()
+        self._generator = generator
+        self._method = method
+
+    def run(self) -> None:
+        getattr(self._generator, self._method)()

--- a/src/ui/output_window.py
+++ b/src/ui/output_window.py
@@ -1,6 +1,5 @@
-from PySide6.QtCore import QTimer, Slot
-from PySide6.QtWidgets import QWidget
-from PySide6.QtWidgets import QDialog, QAbstractItemView
+from PySide6.QtCore import QTimer
+from PySide6.QtWidgets import QDialog, QAbstractItemView, QPushButton
 
 from display import (
     OutputInterfaceAbstraction,
@@ -8,18 +7,16 @@ from display import (
     QtOutput,
 )
 
-from .base_ui import BaseUi
 from .generated import OutputWindowUi
 from abc import ABCMeta
 
 
-class _WidgetABCMeta(type(QWidget), ABCMeta):
-    """Combine Qt's widget metaclass with :class:`ABCMeta`."""
+class _DialogABCMeta(type(QDialog), ABCMeta):
+    """Combine Qt's dialog metaclass with :class:`ABCMeta`."""
     pass
 
 
-
-class OutputWindow(BaseUi, OutputInterfaceAbstraction, metaclass=_WidgetABCMeta):
+class OutputWindow(QDialog, OutputInterfaceAbstraction, metaclass=_DialogABCMeta):
     """Simple dialog used to present generation results."""
 
     def __init__(self, parent: QDialog | None = None) -> None:
@@ -33,6 +30,10 @@ class OutputWindow(BaseUi, OutputInterfaceAbstraction, metaclass=_WidgetABCMeta)
         super().__init__(parent)
         self.ui = OutputWindowUi()
         self.ui.setupUi(self)
+
+        self.close_button = QPushButton("Close", self)
+        self.close_button.clicked.connect(self.close)
+        self.ui.verticalLayout.addWidget(self.close_button)
 
         # Output interface implementation for the log list widget
         self._output = QtOutput(self.ui.logOutputList)


### PR DESCRIPTION
## Summary
- allow `OutputWindow` to operate as a dialog and add a close button
- introduce `GeneratorWorker` thread to run generation tasks
- expose helper methods in `MarketFacade` for creating `FileGenerator` instances
- start file generation in background threads from `MainWindow`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688688f558f88322845bc43adcd634a4