### PR TITLE
Remove unused imports and clean __exit__

### DIFF
--- a/src/backend/basic_db_connector.py
+++ b/src/backend/basic_db_connector.py
@@ -56,7 +56,7 @@ class BasicDBConnector:
              self.connect() # connect() raises error on failure
         return self
 
-    def __exit__(self, exc_type, exc_val, exc_tb):
+    def __exit__(self, *_exc):
         """Leave the context manager and close the connection."""
         self.disconnect()
         return False # Propagate exceptions from the with block

--- a/src/data/market_config_handler.py
+++ b/src/data/market_config_handler.py
@@ -17,7 +17,7 @@ except Exception:  # pragma: no cover - optional PySide6
             pass
 
 from pathlib import Path
-from typing import Any, Dict, TYPE_CHECKING, Union
+from typing import Any, Dict, Union
 
 from .json_handler import JsonHandler
 from .data_manager import DataManager

--- a/src/generator/file_generator.py
+++ b/src/generator/file_generator.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from pathlib import Path
 import time
-from typing import List, Optional, Sequence, Tuple, Protocol
+from typing import List, Optional, Sequence, Tuple
 from log import CustomLogger  # type: ignore
 from display import (
     OutputInterfaceAbstraction,                      # type: ignore

--- a/src/generator/price_list_generator.py
+++ b/src/generator/price_list_generator.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import List, Optional, Sequence, Protocol
+from typing import List, Optional, Sequence
 from log import CustomLogger  # type: ignore
 from display import (
     ProgressTrackerAbstraction as _TrackerBase,  # type: ignore

--- a/src/generator/receive_info_pdf_generator.py
+++ b/src/generator/receive_info_pdf_generator.py
@@ -19,7 +19,7 @@ try:
 except Exception:  # pragma: no cover - optional dependency
     ProgressBarAbstraction = None  # type: ignore
 
-from pypdf import PdfReader, PdfWriter, PageObject
+from pypdf import PdfReader, PdfWriter
 from reportlab.pdfgen import canvas
 
 from reportlab.lib.units import mm


### PR DESCRIPTION
## Summary
- drop unused imports from generator and data modules
- drop unused PageObject import
- update `__exit__` signature to suppress unused params

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68869583a18883228119a69106ed60e8