### PR TITLE
Implement optional PySide6 imports

### DIFF
--- a/tests/test_coordinates_conversion.py
+++ b/tests/test_coordinates_conversion.py
@@ -9,17 +9,21 @@ def test_coordinate_list_generation():
     # Inject src directory
     sys.path.insert(0, str(Path(__file__).resolve().parents[1] / 'src'))
 
-    # ----- provide minimal stubs -----
     pyside6 = types.ModuleType('PySide6')
     qtcore = types.ModuleType('PySide6.QtCore')
-    class QObject: pass
-    class Signal:
+
+    class QObject:  # pragma: no cover - simple stub
+        pass
+
+    class Signal:  # pragma: no cover - simple stub
         def __init__(self, *a, **kw):
             pass
+
     qtcore.QObject = QObject
     qtcore.Signal = Signal
-    sys.modules.setdefault('PySide6', pyside6)
+    sys.modules['PySide6'] = pyside6
     sys.modules['PySide6.QtCore'] = qtcore
+    restore_pyside = True
 
     objects_mod = types.ModuleType('objects')
     @dataclasses.dataclass
@@ -94,3 +98,13 @@ def test_coordinate_list_generation():
     assert (c1.x1, c1.y1, c1.x2, c1.y2, c1.x3, c1.y3) == (1, 2, 3, 4, 10, 11)
     assert (c2.x1, c2.y1, c2.x2, c2.y2, c2.x3, c2.y3) == (5, 6, 7, 8, 0, 0)
     assert (c3.x1, c3.y1, c3.x2, c3.y2, c3.x3, c3.y3) == (0, 0, 0, 0, 12, 13)
+
+    if restore_pyside:
+        sys.modules.pop('PySide6.QtCore', None)
+        sys.modules.pop('PySide6', None)
+
+    sys.modules.pop('data.pdf_display_config', None)
+    sys.modules.pop('data.json_handler', None)
+    sys.modules.pop('data', None)
+    sys.modules.pop('objects', None)
+    sys.modules.pop('requests', None)

--- a/tests/test_main_window.py
+++ b/tests/test_main_window.py
@@ -6,7 +6,11 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
 
 pytest.importorskip("PySide6")
 
-from PySide6.QtWidgets import QMainWindow  # noqa: E402
+try:
+    from PySide6.QtWidgets import QMainWindow  # noqa: E402
+except Exception:  # pragma: no cover - environment without QtWidgets
+    pytest.skip("QtWidgets not available", allow_module_level=True)
+
 from ui.main_window import MainWindow  # noqa: E402
 
 

--- a/tests/test_pdf_display_config_dpi.py
+++ b/tests/test_pdf_display_config_dpi.py
@@ -7,17 +7,21 @@ from pathlib import Path
 def test_dpi_getter_setter():
     sys.path.insert(0, str(Path(__file__).resolve().parents[1] / 'src'))
 
-    # minimal PySide6 stubs
     pyside6 = types.ModuleType('PySide6')
     qtcore = types.ModuleType('PySide6.QtCore')
-    class QObject: pass
-    class Signal:
+
+    class QObject:  # pragma: no cover - simple stub
+        pass
+
+    class Signal:  # pragma: no cover - simple stub
         def __init__(self, *a, **kw):
             pass
+
     qtcore.QObject = QObject
     qtcore.Signal = Signal
-    sys.modules.setdefault('PySide6', pyside6)
+    sys.modules['PySide6'] = pyside6
     sys.modules['PySide6.QtCore'] = qtcore
+    restore_pyside = True
 
     # stubs for dependencies used by PdfDisplayConfig
     requests_stub = types.ModuleType('requests')
@@ -65,3 +69,13 @@ def test_dpi_getter_setter():
     assert cfg.get_dpi() == 150
     cfg.set_dpi(200)
     assert cfg.get_dpi() == 200
+
+    if restore_pyside:
+        sys.modules.pop('PySide6.QtCore', None)
+        sys.modules.pop('PySide6', None)
+
+    sys.modules.pop('data.pdf_display_config', None)
+    sys.modules.pop('data.json_handler', None)
+    sys.modules.pop('data', None)
+    sys.modules.pop('objects', None)
+    sys.modules.pop('requests', None)

--- a/tests/test_project_creation.py
+++ b/tests/test_project_creation.py
@@ -22,9 +22,42 @@ class DummyMarket:
 
 
 def test_load_export_creates_project(tmp_path):
-    export = Path(__file__).parent / "test_dataset.json"
+    export_src = Path(__file__).parent / "test_dataset.json"
+    export = tmp_path / export_src.name
+    export.write_text(export_src.read_text())
+
+    import types, sys
+    pyside6 = types.ModuleType('PySide6')
+    qtcore = types.ModuleType('PySide6.QtCore')
+    qtwidgets = types.ModuleType('PySide6.QtWidgets')
+    class QObject: pass
+    class Signal:
+        def __init__(self, *a, **k):
+            pass
+    qtcore.QObject = QObject
+    qtcore.Signal = Signal
+    class QFileDialog:
+        @staticmethod
+        def getExistingDirectory(*a, **k):
+            return str(tmp_path)
+    qtwidgets.QFileDialog = QFileDialog
+    pyside6.QtCore = qtcore
+    pyside6.QtWidgets = qtwidgets
+    sys.modules['PySide6'] = pyside6
+    sys.modules['PySide6.QtCore'] = qtcore
+    sys.modules['PySide6.QtWidgets'] = qtwidgets
+
+    import data.market_facade as mf
+    from data.market_facade import MarketFacade, MarketObserver
+    original_get_dir = mf.QFileDialog.getExistingDirectory
+    mf.QFileDialog.getExistingDirectory = staticmethod(lambda *a, **k: str(tmp_path))
+    original_get_dir = mf.QFileDialog.getExistingDirectory
+    mf.QFileDialog.getExistingDirectory = staticmethod(lambda *a, **k: str(tmp_path))
     facade = MarketFacade()
     market = DummyMarket()
+
+    facade._ask_for_project_creation = lambda: True
+    MarketObserver._ask_for_default_pdf_config = lambda self: False
 
     ret = facade.load_local_market_export(market, str(export))
     assert ret is True
@@ -32,5 +65,8 @@ def test_load_export_creates_project(tmp_path):
     observer = facade.get_observer(market)
     assert observer is not None
     assert observer.project_exists()
-    assert observer.market_config_handler.get_full_market_path() == str(export)
+    assert observer.market_config_handler.get_full_market_path() == str(Path(tmp_path) / export.name)
+    mf.QFileDialog.getExistingDirectory = original_get_dir
+    for mod in ['PySide6.QtWidgets', 'PySide6.QtCore', 'PySide6']:
+        sys.modules.pop(mod, None)
 


### PR DESCRIPTION
## Summary
- drop the PySide6 stub package
- make Qt imports optional in the data layer
- provide light fallbacks so non‑GUI tests run without PySide6

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688778ae9b5c8322b7baddaa943ddd26