### PR TITLE
Fix PDF copy when saving project

### DIFF
--- a/src/data/market_facade.py
+++ b/src/data/market_facade.py
@@ -409,7 +409,10 @@ class MarketObserver(QObject):
 
             pdf_path = self.pdf_display_config_loader.get_full_pdf_path()
             if pdf_path and Path(pdf_path).is_file():
-                shutil.copy(pdf_path, target_dir / Path(pdf_path).name)
+                destination = target_dir / Path(pdf_path).name
+                if Path(pdf_path).resolve() != destination.resolve():
+                    shutil.copy(pdf_path, destination)
+                self.pdf_display_config_loader.set_full_pdf_path(str(destination))
 
             self.set_project_dir(dir_path)
             self.set_project_exists(True)

--- a/tests/test_save_project.py
+++ b/tests/test_save_project.py
@@ -57,3 +57,13 @@ def test_facade_save_project(tmp_path):
     assert (tmp_path / pdf.name).is_file()
     assert facade.is_project(market)
     assert facade.get_project_dir(market) == str(tmp_path)
+
+
+def test_save_project_same_pdf_path(tmp_path):
+    obs = _prepare_observer()
+    pdf_file = tmp_path / 'Abholung_Template.pdf'
+    pdf_file.write_text('dummy')
+    obs.pdf_display_config_loader.set_full_pdf_path(str(pdf_file))
+
+    assert obs.save_project(str(tmp_path))
+    assert pdf_file.is_file()


### PR DESCRIPTION
## Summary
- avoid SameFileError when copying PDF on save
- update PDF path in project
- add regression test for saving with template already in target directory

## Testing
- `pip install -r requirements-test.txt`
- `pip install requests pypdf reportlab`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6887e7810f688322bb245b8b6cfca94b