### PR TITLE
Add dialog to edit database settings

### DIFF
--- a/src/ui/database_settings_dialog.py
+++ b/src/ui/database_settings_dialog.py
@@ -1,0 +1,67 @@
+"""Dialog to edit database connection settings."""
+
+from __future__ import annotations
+
+from PySide6.QtGui import QIntValidator
+from PySide6.QtWidgets import (
+    QDialog,
+    QDialogButtonBox,
+    QFormLayout,
+    QLineEdit,
+)
+
+from data import MarketConfigHandler
+
+
+class DatabaseSettingsDialog(QDialog):
+    """Collect and return database connection parameters.
+
+    The dialog provides line edits for host, port, database name, user and
+    password.  Existing values are taken from :class:`MarketConfigHandler` to
+    give the user a starting point.
+    """
+
+    def __init__(self, parent: QDialog | None = None) -> None:
+        super().__init__(parent)
+        self.setWindowTitle("Datenbankeinstellungen")
+
+        self._host_edit = QLineEdit(self)
+        self._port_edit = QLineEdit(self)
+        self._port_edit.setValidator(QIntValidator(1, 65535, self))
+        self._name_edit = QLineEdit(self)
+        self._user_edit = QLineEdit(self)
+        self._password_edit = QLineEdit(self)
+        self._password_edit.setEchoMode(QLineEdit.EchoMode.Password)
+
+        try:
+            db_cfg = MarketConfigHandler().get_database()
+        except Exception:
+            db_cfg = {}
+        self._host_edit.setText(db_cfg.get("url", ""))
+        self._port_edit.setText(db_cfg.get("port", ""))
+        self._name_edit.setText(db_cfg.get("name", ""))
+        self._user_edit.setText(db_cfg.get("user", ""))
+
+        form = QFormLayout(self)
+        form.addRow("Host", self._host_edit)
+        form.addRow("Port", self._port_edit)
+        form.addRow("DB-Name", self._name_edit)
+        form.addRow("Benutzer", self._user_edit)
+        form.addRow("Passwort", self._password_edit)
+
+        buttons = QDialogButtonBox(
+            QDialogButtonBox.Ok | QDialogButtonBox.Cancel, parent=self
+        )
+        buttons.accepted.connect(self.accept)
+        buttons.rejected.connect(self.reject)
+        form.addWidget(buttons)
+
+    def get_values(self) -> tuple[str, str, str, str, str]:
+        """Return entered connection parameters."""
+        return (
+            self._host_edit.text().strip(),
+            self._port_edit.text().strip(),
+            self._name_edit.text().strip(),
+            self._user_edit.text().strip(),
+            self._password_edit.text(),
+        )

--- a/tests/test_database_settings_dialog.py
+++ b/tests/test_database_settings_dialog.py
@@ -1,0 +1,60 @@
+import sys
+from pathlib import Path
+
+import os
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+pytest.importorskip("PySide6")
+
+from PySide6.QtWidgets import QApplication, QDialog, QMainWindow
+
+from data.market_config_handler import MarketConfigHandler
+from ui import main_window as mw_module
+from ui import database_settings_dialog as dlg_module
+
+
+class _Dialog(dlg_module.DatabaseSettingsDialog):
+    def exec(self):  # pragma: no cover - simple override
+        self._host_edit.setText("newhost")
+        self._port_edit.setText("5432")
+        self._name_edit.setText("newdb")
+        self._user_edit.setText("newuser")
+        self._password_edit.setText("secret")
+        return QDialog.DialogCode.Accepted
+
+
+def test_database_settings_applied(monkeypatch):
+    app = QApplication.instance() or QApplication([])  # noqa: F841 - keep reference
+
+    mch = MarketConfigHandler()
+    mch.set_database("oldhost", "1111")
+    mch.set_db_credentials("olddb", "olduser")
+
+    monkeypatch.setattr(mw_module, "MarketConfigHandler", lambda: mch)
+    monkeypatch.setattr(dlg_module, "MarketConfigHandler", lambda: mch)
+    monkeypatch.setattr(mw_module, "DatabaseSettingsDialog", _Dialog)
+
+    saved = {"called": False}
+
+    def fake_save_project(self):
+        saved["called"] = True
+
+    monkeypatch.setattr(mw_module.MainWindow, "save_project", fake_save_project)
+
+    def dummy_init(self):
+        QMainWindow.__init__(self)
+
+    monkeypatch.setattr(mw_module.MainWindow, "__init__", dummy_init)
+
+    mw = mw_module.MainWindow()
+    mw.open_database_settings_dialog()
+
+    db = mch.get_database()
+    assert db["url"] == "newhost"
+    assert db["port"] == "5432"
+    assert db["name"] == "newdb"
+    assert db["user"] == "newuser"
+    assert saved["called"]


### PR DESCRIPTION
## Summary
- add `DatabaseSettingsDialog` to edit host, port, database name, user and password
- wire main window with a new action that opens the dialog and saves updated settings
- cover behavior with a UI test that simulates user input and checks `MarketConfigHandler`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aa464ca4b48322989c43e39a1d735d