### PR TITLE
Remove warning when cancelling market load

### DIFF
--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -179,8 +179,6 @@ class MainWindow(QMainWindow):
             # self.market_view.set_data(market_data)
             if ret:
                 self.open_view("Market")
-        else:
-            QMessageBox.warning(self, "Warning", "No market data loaded. Please try again.")
 
     @Slot()
     def create_new_market(self):


### PR DESCRIPTION
## Summary
- Remove warning shown when cancelling the market loader dialog

## Testing
- `pytest -q` *(fails: ImportError: libGL.so.1: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68aac334dba88322899e7ac46fbecfe7