### PR TITLE
Refactor project export workflow

### DIFF
--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -152,8 +152,39 @@ class MainWindow(QMainWindow):
         local_json = self.open_file_dialog()
         if local_json is None:
             return
-        self.market_facade.load_local_market_export(self.market_view, local_json)
-        self.open_view("Market")
+
+        export_path = Path(local_json)
+
+        reply = QMessageBox.question(
+            self,
+            "Projekt erstellen",
+            "Soll aus dem Export ein Projekt erstellt werden?",
+            QMessageBox.Yes | QMessageBox.No,
+            QMessageBox.Yes,
+        )
+
+        if reply == QMessageBox.Yes:
+            chosen_dir = QFileDialog.getExistingDirectory(
+                self, "Projektordner wählen"
+            )
+            if not chosen_dir:
+                return
+            ok, target = self.market_facade.create_project_from_export(
+                self.market_view, local_json, chosen_dir
+            )
+            if not ok:
+                QMessageBox.critical(
+                    self, "Fehler", "Projekt konnte nicht erstellt werden."
+                )
+                return
+            export_path = Path(target) / export_path.name
+            local_json = str(export_path)
+
+        ret = self.market_facade.load_local_market_export(
+            self.market_view, local_json
+        )
+        if ret:
+            self.open_view("Market")
 
     @Slot()
     def open_market_view(self):

--- a/tests/test_project_creation.py
+++ b/tests/test_project_creation.py
@@ -1,22 +1,106 @@
 import sys
 from pathlib import Path
-import pytest
+import types
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
 
-pytest.importorskip("PySide6")
+# Provide minimal PySide6 stubs for test environment
+qtcore = types.ModuleType("PySide6.QtCore")
+qtwidgets = types.ModuleType("PySide6.QtWidgets")
+
+
+class QObject:  # pragma: no cover - simple stub
+    pass
+
+
+class Signal:  # pragma: no cover - simple stub
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def connect(self, *args, **kwargs):
+        pass
+
+    def emit(self, *args, **kwargs):
+        pass
+
+
+def Slot(*args, **kwargs):  # pragma: no cover - simple stub
+    def decorator(func):
+        return func
+    return decorator
+
+
+class QMessageBox:  # pragma: no cover - simple stub
+    Yes = 0
+    No = 1
+    Question = 2
+
+    def setIcon(self, *args, **kwargs):
+        pass
+
+    def setWindowTitle(self, *args, **kwargs):
+        pass
+
+    def setText(self, *args, **kwargs):
+        pass
+
+    def setStandardButtons(self, *args, **kwargs):
+        pass
+
+    def setDefaultButton(self, *args, **kwargs):
+        pass
+
+    def exec(self):
+        return QMessageBox.No
+
+
+qtcore.QObject = QObject
+qtcore.Signal = Signal
+qtcore.Slot = Slot
+class QThread:  # pragma: no cover - simple stub
+    def start(self):
+        pass
+
+    def quit(self):
+        pass
+
+    def wait(self):
+        pass
+
+qtcore.QThread = QThread
+class QTimer:  # pragma: no cover - simple stub
+    def start(self):
+        pass
+
+    def stop(self):
+        pass
+
+qtcore.QTimer = QTimer
+qtwidgets.QMessageBox = QMessageBox
+
+pyside6 = types.ModuleType("PySide6")
+pyside6.QtCore = qtcore
+pyside6.QtWidgets = qtwidgets
+
+sys.modules.setdefault("PySide6", pyside6)
+sys.modules.setdefault("PySide6.QtCore", qtcore)
+sys.modules.setdefault("PySide6.QtWidgets", qtwidgets)
 
 from data.market_facade import MarketFacade
+
 
 class DummySignal:
     def connect(self, *args, **kwargs):
         pass
 
+
 class DummyMarket:
     def __init__(self):
         self.pdf_display_storage_path_changed = DummySignal()
+
     def set_market_data(self, *args, **kwargs):
         pass
+
     def set_pdf_config(self, *args, **kwargs):
         pass
 
@@ -26,47 +110,24 @@ def test_load_export_creates_project(tmp_path):
     export = tmp_path / export_src.name
     export.write_text(export_src.read_text())
 
-    import types, sys
-    pyside6 = types.ModuleType('PySide6')
-    qtcore = types.ModuleType('PySide6.QtCore')
-    qtwidgets = types.ModuleType('PySide6.QtWidgets')
-    class QObject: pass
-    class Signal:
-        def __init__(self, *a, **k):
-            pass
-    qtcore.QObject = QObject
-    qtcore.Signal = Signal
-    class QFileDialog:
-        @staticmethod
-        def getExistingDirectory(*a, **k):
-            return str(tmp_path)
-    qtwidgets.QFileDialog = QFileDialog
-    pyside6.QtCore = qtcore
-    pyside6.QtWidgets = qtwidgets
-    sys.modules['PySide6'] = pyside6
-    sys.modules['PySide6.QtCore'] = qtcore
-    sys.modules['PySide6.QtWidgets'] = qtwidgets
-
-    import data.market_facade as mf
-    from data.market_facade import MarketFacade, MarketObserver
-    original_get_dir = mf.QFileDialog.getExistingDirectory
-    mf.QFileDialog.getExistingDirectory = staticmethod(lambda *a, **k: str(tmp_path))
-    original_get_dir = mf.QFileDialog.getExistingDirectory
-    mf.QFileDialog.getExistingDirectory = staticmethod(lambda *a, **k: str(tmp_path))
     facade = MarketFacade()
     market = DummyMarket()
-
-    facade._ask_for_project_creation = lambda: True
-    MarketObserver._ask_for_default_pdf_config = lambda self: False
 
     ret = facade.load_local_market_export(market, str(export))
     assert ret is True
 
     observer = facade.get_observer(market)
     assert observer is not None
+
+    observer._ask_for_default_pdf_config = lambda: False
+    ok, target = facade.create_project_from_export(
+        market, str(export), str(tmp_path)
+    )
+
+    assert ok is True
     assert observer.project_exists()
-    assert observer.market_config_handler.get_full_market_path() == str(Path(tmp_path) / export.name)
-    mf.QFileDialog.getExistingDirectory = original_get_dir
-    for mod in ['PySide6.QtWidgets', 'PySide6.QtCore', 'PySide6']:
-        sys.modules.pop(mod, None)
+    assert (
+        observer.market_config_handler.get_full_market_path()
+        == str(Path(tmp_path) / export.name)
+    )
 

--- a/tests/test_project_file_name.py
+++ b/tests/test_project_file_name.py
@@ -1,8 +1,71 @@
 import sys
 from pathlib import Path
 import shutil
+import types
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / 'src'))
+
+# Provide minimal PySide6 stubs for test environment
+qtcore = types.ModuleType("PySide6.QtCore")
+qtwidgets = types.ModuleType("PySide6.QtWidgets")
+
+
+class QObject:  # pragma: no cover - simple stub
+    pass
+
+
+class Signal:  # pragma: no cover - simple stub
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def connect(self, *args, **kwargs):
+        pass
+
+    def emit(self, *args, **kwargs):
+        pass
+
+
+def Slot(*args, **kwargs):  # pragma: no cover - simple stub
+    def decorator(func):
+        return func
+    return decorator
+
+
+class QMessageBox:  # pragma: no cover - simple stub
+    pass
+
+
+qtcore.QObject = QObject
+qtcore.Signal = Signal
+qtcore.Slot = Slot
+class QThread:  # pragma: no cover - simple stub
+    def start(self):
+        pass
+
+    def quit(self):
+        pass
+
+    def wait(self):
+        pass
+
+qtcore.QThread = QThread
+class QTimer:  # pragma: no cover - simple stub
+    def start(self):
+        pass
+
+    def stop(self):
+        pass
+
+qtcore.QTimer = QTimer
+qtwidgets.QMessageBox = QMessageBox
+
+pyside6 = types.ModuleType("PySide6")
+pyside6.QtCore = qtcore
+pyside6.QtWidgets = qtwidgets
+
+sys.modules.setdefault("PySide6", pyside6)
+sys.modules.setdefault("PySide6.QtCore", qtcore)
+sys.modules.setdefault("PySide6.QtWidgets", qtwidgets)
 
 from data.market_facade import MarketFacade
 


### PR DESCRIPTION
## Summary
- Remove Qt widget prompts from `MarketFacade` and require explicit target directory for project creation from exports
- Let `MainWindow` handle user prompts and pass final parameters to the facade
- Adjust tests for new facade API using lightweight PySide6 stubs

## Testing
- `pytest -q` *(fails: libGL.so.1: cannot open shared object file)*
- `pytest tests/test_project_creation.py tests/test_project_file_name.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68aaf9b6286c8322a3d5a3e115fcebc7