### PR TITLE
Introduce project creation service

### DIFF
--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -23,6 +23,7 @@ from data import MarketFacade
 from .status_bar import StatusBar
 from .new_market_dialog import NewMarketDialog
 from .database_settings_dialog import DatabaseSettingsDialog
+from .project_service import ProjectService
 from backend import SQLiteInterface
 
 
@@ -219,58 +220,11 @@ class MainWindow(QMainWindow):
         if not name:
             return
 
-        # Ask whether to also create a local project now
-        reply = QMessageBox.question(
-            self,
-            "Projekt anlegen",
-            "Möchten Sie zusätzlich sofort ein lokales Projekt erstellen?",
-            QMessageBox.Yes | QMessageBox.No,
-            QMessageBox.Yes,
-        )
-
-        if reply == QMessageBox.Yes:
-            # Choose target directory
-            chosen_dir = QFileDialog.getExistingDirectory(self, "Projektordner wählen")
-            if not chosen_dir:
-                return
-
-            # Ensure filename has .json
-            market_filename = name if name.lower().endswith('.json') else f"{name}.json"
-
-            # Check for existing files and confirm overwrite
-            target_dir = Path(chosen_dir)
-            candidates = [
-                target_dir / market_filename,
-                target_dir / "pdf_display_config.json",
-                target_dir / "project.project",
-                target_dir / "Abholung_Template.pdf",
-            ]
-            existing = [str(p.name) for p in candidates if p.exists()]
-            if existing:
-                msg = (
-                    "Im Zielordner existieren bereits folgende Dateien:\n\n" +
-                    "\n".join(f"- {n}" for n in existing) +
-                    "\n\nÜberschreiben?"
-                )
-                confirm = QMessageBox.warning(
-                    self,
-                    "Dateien überschreiben?",
-                    msg,
-                    QMessageBox.Yes | QMessageBox.No,
-                    QMessageBox.No,
-                )
-                if confirm != QMessageBox.Yes:
-                    return
-
-            ok = self.market_facade.create_new_project(
-                self.market_view,
-                chosen_dir,
-                market_filename,
-                settings=settings,
-                server_info=server,
-            )
-            if ok:
-                self.open_view("Market")
+        service = ProjectService(self, self.market_facade)
+        if service.create_new_project(
+            self.market_view, name, settings=settings, server_info=server
+        ):
+            self.open_view("Market")
 
     @Slot()
     def switch_to_last_view(self):

--- a/src/ui/project_service.py
+++ b/src/ui/project_service.py
@@ -1,0 +1,184 @@
+from __future__ import annotations
+
+"""Utility service for project creation dialogs and facade calls."""
+
+from pathlib import Path
+from typing import Any, Tuple
+
+from PySide6.QtWidgets import QFileDialog, QMessageBox, QWidget
+
+from data import MarketFacade
+
+
+class ProjectService:
+    """Service class handling project creation workflows.
+
+    This class encapsulates user interactions required for creating new
+    projects or projects from exports. It provides convenience methods to
+    choose target directories, confirm overwriting of existing files and
+    delegate the actual creation work to :class:`data.market_facade.MarketFacade`.
+    """
+
+    def __init__(self, parent: QWidget, facade: MarketFacade) -> None:
+        """Initialise the service.
+
+        Parameters
+        ----------
+        parent:
+            Parent widget used for dialogs.
+        facade:
+            Facade instance used for project operations.
+        """
+        self._parent = parent
+        self._facade = facade
+
+    # ------------------------------------------------------------------
+    # Helper dialogs
+    # ------------------------------------------------------------------
+    def _select_directory(self) -> str | None:
+        """Ask the user to select a project directory."""
+        return QFileDialog.getExistingDirectory(self._parent, "Projektordner wählen") or None
+
+    def _confirm_overwrite(self, candidates: list[Path]) -> bool:
+        """Confirm overwriting existing files.
+
+        Parameters
+        ----------
+        candidates:
+            List of file paths to check for existence.
+
+        Returns
+        -------
+        bool
+            ``True`` if overwriting is accepted or no file exists, ``False`` otherwise.
+        """
+        existing = [p.name for p in candidates if p.exists()]
+        if not existing:
+            return True
+        msg = (
+            "Im Zielordner existieren bereits folgende Dateien:\n\n"
+            + "\n".join(f"- {name}" for name in existing)
+            + "\n\nÜberschreiben?"
+        )
+        reply = QMessageBox.warning(
+            self._parent,
+            "Dateien überschreiben?",
+            msg,
+            QMessageBox.Yes | QMessageBox.No,
+            QMessageBox.No,
+        )
+        return reply == QMessageBox.Yes
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+    def create_new_project(
+        self,
+        market,
+        name: str,
+        settings: Any | None = None,
+        server_info: dict | None = None,
+    ) -> bool:
+        """Create a new local project after user confirmation.
+
+        This method asks whether a local project should be created, lets the
+        user choose a target directory and verifies whether important files
+        already exist. If everything is accepted the facade's
+        :func:`MarketFacade.create_new_project` method is invoked.
+
+        Parameters
+        ----------
+        market:
+            Target :class:`ui.market.Market` view.
+        name:
+            Desired project (and JSON) file name, without or with ``.json``.
+        settings:
+            Optional settings used for project initialisation.
+        server_info:
+            Optional server configuration to store in the project.
+
+        Returns
+        -------
+        bool
+            ``True`` if the project was created successfully, ``False`` otherwise.
+        """
+        reply = QMessageBox.question(
+            self._parent,
+            "Projekt anlegen",
+            "Möchten Sie zusätzlich sofort ein lokales Projekt erstellen?",
+            QMessageBox.Yes | QMessageBox.No,
+            QMessageBox.Yes,
+        )
+        if reply != QMessageBox.Yes:
+            return False
+
+        chosen_dir = self._select_directory()
+        if not chosen_dir:
+            return False
+
+        market_filename = name if name.lower().endswith(".json") else f"{name}.json"
+        target_dir = Path(chosen_dir)
+        candidates = [
+            target_dir / market_filename,
+            target_dir / "pdf_display_config.json",
+            target_dir / "project.project",
+            target_dir / "Abholung_Template.pdf",
+        ]
+        if not self._confirm_overwrite(candidates):
+            return False
+
+        return self._facade.create_new_project(
+            market,
+            chosen_dir,
+            market_filename,
+            settings=settings,
+            server_info=server_info,
+        )
+
+    def create_project_from_export(
+        self, market, export_path: str
+    ) -> Tuple[bool, str | None]:
+        """Create a project using an existing export file.
+
+        The user is asked to select a target directory and confirm
+        overwriting if the export file already exists in the chosen
+        directory. On success the facade's
+        :func:`MarketFacade.create_project_from_export` is used and the
+        resulting project path is returned.
+
+        Parameters
+        ----------
+        market:
+            Target :class:`ui.market.Market` view.
+        export_path:
+            Path to the export JSON file.
+
+        Returns
+        -------
+        tuple[bool, str | None]
+            ``(True, path)`` on success where ``path`` points to the moved
+            export file. ``(False, None)`` otherwise.
+        """
+        chosen_dir = self._select_directory()
+        if not chosen_dir:
+            return False, None
+
+        export_file = Path(export_path)
+        target_file = Path(chosen_dir) / export_file.name
+        if target_file.exists():
+            reply = QMessageBox.warning(
+                self._parent,
+                "Datei überschreiben?",
+                f"Die Datei {export_file.name} existiert bereits.\nÜberschreiben?",
+                QMessageBox.Yes | QMessageBox.No,
+                QMessageBox.No,
+            )
+            if reply != QMessageBox.Yes:
+                return False, None
+
+        ok, target = self._facade.create_project_from_export(
+            market, export_path, chosen_dir
+        )
+        if ok and target:
+            return True, str(Path(target) / export_file.name)
+        return False, None


### PR DESCRIPTION
## Summary
- add ProjectService to manage directory selection, overwrite prompts, and facade calls for project creation
- use ProjectService from MainWindow.create_new_market

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aafb88b6908322a2fd7d771e41ee90