### PR TITLE
Refactor project creation with reusable file check helper

### DIFF
--- a/src/data/market_observer.py
+++ b/src/data/market_observer.py
@@ -6,6 +6,8 @@ import shutil
 from PySide6.QtCore import QObject, Slot, Signal
 from PySide6.QtWidgets import QMessageBox
 
+from ui.utils.file_checks import check_existing_files
+
 from display import BasicProgressTracker
 from generator.file_generator import FileGenerator
 from objects import FleatMarket
@@ -204,6 +206,14 @@ class MarketObserver(QObject):
 
         cfg_dst = project_dir / "pdf_display_config.json"
         pdf_dst = project_dir / "Abholung_Template.pdf"
+
+        _, proceed = check_existing_files(
+            project_dir,
+            [cfg_dst.name, pdf_dst.name],
+            confirm=True,
+        )
+        if not proceed:
+            return
 
         shutil.copy(cfg_src, cfg_dst)
         shutil.copy(pdf_src, pdf_dst)

--- a/src/ui/__init__.py
+++ b/src/ui/__init__.py
@@ -5,14 +5,25 @@ Generated code from Qt Designer lives in `src/ui/generated` and should not be
 edited manually.
 """
 
-from .main_menu import MainMenu
-from .main_window import MainWindow
-from .market_loader_dialog import MarketLoaderDialog
-from .new_market_dialog import NewMarketDialog
-
 __all__ = [
     "MainMenu",
     "MainWindow",
     "MarketLoaderDialog",
     "NewMarketDialog",
 ]
+
+
+def __getattr__(name: str):  # pragma: no cover - simple delegation
+    if name == "MainMenu":
+        from .main_menu import MainMenu
+        return MainMenu
+    if name == "MainWindow":
+        from .main_window import MainWindow
+        return MainWindow
+    if name == "MarketLoaderDialog":
+        from .market_loader_dialog import MarketLoaderDialog
+        return MarketLoaderDialog
+    if name == "NewMarketDialog":
+        from .new_market_dialog import NewMarketDialog
+        return NewMarketDialog
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -23,7 +23,7 @@ from data import MarketFacade
 from .status_bar import StatusBar
 from .new_market_dialog import NewMarketDialog
 from .database_settings_dialog import DatabaseSettingsDialog
-from .project_service import ProjectService
+from .project_creation_service import ProjectCreationService
 from backend import SQLiteInterface
 
 
@@ -220,7 +220,7 @@ class MainWindow(QMainWindow):
         if not name:
             return
 
-        service = ProjectService(self, self.market_facade)
+        service = ProjectCreationService(self, self.market_facade)
         if service.create_new_project(
             self.market_view, name, settings=settings, server_info=server
         ):

--- a/src/ui/utils/file_checks.py
+++ b/src/ui/utils/file_checks.py
@@ -1,0 +1,68 @@
+"""Utilities for file existence checks with optional user confirmation."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Sequence, Tuple, TYPE_CHECKING
+
+from PySide6.QtWidgets import QMessageBox
+
+if TYPE_CHECKING:  # pragma: no cover - imported for type hints only
+    from PySide6.QtWidgets import QWidget
+
+
+def check_existing_files(
+    target_dir: str | Path,
+    expected_files: Sequence[str | Path],
+    *,
+    parent: "QWidget" | None = None,
+    confirm: bool = False,
+) -> Tuple[list[str], bool]:
+    """Check whether expected files exist in *target_dir*.
+
+    Parameters
+    ----------
+    target_dir:
+        Directory in which to check for files.
+    expected_files:
+        Sequence of file names or paths to validate. Relative paths are
+        resolved against ``target_dir``. Only the file names are returned.
+    parent:
+        Optional parent widget used for confirmation dialogs.
+    confirm:
+        If ``True`` and any file exists, a confirmation dialog asking
+        whether to overwrite is shown.
+
+    Returns
+    -------
+    tuple[list[str], bool]
+        ``(existing, proceed)`` where ``existing`` contains the names of
+        files already present in ``target_dir`` and ``proceed`` indicates
+        whether the caller may continue (``False`` when confirmation was
+        denied).
+    """
+    dir_path = Path(target_dir)
+    existing: list[str] = []
+    for f in expected_files:
+        path = Path(f)
+        path = dir_path / path.name if not path.is_absolute() else path
+        if path.exists():
+            existing.append(path.name)
+
+    proceed = True
+    if confirm and existing:
+        msg = (
+            "Im Zielordner existieren bereits folgende Dateien:\n\n"
+            + "\n".join(f"- {name}" for name in existing)
+            + "\n\nÜberschreiben?"
+        )
+        reply = QMessageBox.warning(
+            parent,
+            "Dateien überschreiben?",
+            msg,
+            QMessageBox.Yes | QMessageBox.No,
+            QMessageBox.No,
+        )
+        proceed = reply == QMessageBox.Yes
+
+    return existing, proceed


### PR DESCRIPTION
## Summary
- add `check_existing_files` utility for confirming required files in a directory
- introduce `ProjectCreationService` that uses the helper when creating projects
- reuse helper in `MarketObserver` to guard default PDF config overwrites
- update main window to use the new service

## Testing
- `pytest -q` *(fails: ImportError: libEGL.so.1: cannot open shared object file)*
- `pytest tests/test_version.py tests/test_project_creation.py tests/test_project_file_name.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68aafdceddb88322b4aca1fbbe88c3f2