### PR TITLE
Add database selection dialog

### DIFF
--- a/src/ui/__init__.py
+++ b/src/ui/__init__.py
@@ -10,6 +10,7 @@ __all__ = [
     "MainWindow",
     "MarketLoaderDialog",
     "NewMarketDialog",
+    "DatabaseSelectionDialog",
 ]
 
 
@@ -26,4 +27,7 @@ def __getattr__(name: str):  # pragma: no cover - simple delegation
     if name == "NewMarketDialog":
         from .new_market_dialog import NewMarketDialog
         return NewMarketDialog
+    if name == "DatabaseSelectionDialog":
+        from .database_selection_dialog import DatabaseSelectionDialog
+        return DatabaseSelectionDialog
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/src/ui/database_selection_dialog.py
+++ b/src/ui/database_selection_dialog.py
@@ -1,0 +1,45 @@
+"""Dialog to select a database from a list."""
+
+from __future__ import annotations
+
+from PySide6.QtWidgets import QDialog
+
+from .generated import DatabaseSelectionDialogUi
+
+
+class DatabaseSelectionDialog(QDialog):
+    """Present a list of database names and return the chosen one.
+
+    Parameters
+    ----------
+    databases:
+        Names of available databases shown in the list.
+    parent:
+        Optional parent widget.
+    """
+
+    def __init__(self, databases: list[str], parent: QDialog | None = None) -> None:
+        super().__init__(parent)
+
+        self.ui = DatabaseSelectionDialogUi()
+        self.ui.setupUi(self)
+        self.ui.databaseList.addItems(databases)
+        if databases:
+            self.ui.databaseList.setCurrentRow(0)
+
+        self.ui.buttonBox.accepted.connect(self.accept)
+        self.ui.buttonBox.rejected.connect(self.reject)
+
+    def get_selection(self) -> str | None:
+        """Return the currently selected database name if dialog accepted.
+
+        Returns
+        -------
+        str | None
+            Selected database name or ``None`` when no selection was made or the dialog was
+            cancelled.
+        """
+        if self.result() != QDialog.DialogCode.Accepted:
+            return None
+        item = self.ui.databaseList.currentItem()
+        return item.text() if item else None

--- a/src/ui/design/database_selection_dialog.ui
+++ b/src/ui/design/database_selection_dialog.ui
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>DatabaseSelectionDialog</class>
+ <widget class="QDialog" name="DatabaseSelectionDialog">
+  <property name="windowTitle">
+   <string>Datenbank auswählen</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QListWidget" name="databaseList"/>
+   </item>
+   <item>
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/src/ui/generated/__init__.py
+++ b/src/ui/generated/__init__.py
@@ -9,3 +9,4 @@ from .pdf_display_ui import Ui_PdfDisplayView as PdfDisplayUi
 from .market_loader_dialog_ui import Ui_MarketLoaderDialog as MarketLoaderUi
 from .output_window_ui import Ui_OutputWindow as OutputWindowUi
 from .market_statistics_ui import Ui_MarketStatistics as MarketStatisticsUi
+from .database_selection_dialog_ui import Ui_DatabaseSelectionDialog as DatabaseSelectionDialogUi

--- a/src/ui/generated/database_selection_dialog_ui.py
+++ b/src/ui/generated/database_selection_dialog_ui.py
@@ -1,0 +1,48 @@
+# -*- coding: utf-8 -*-
+
+################################################################################
+## Form generated from reading UI file 'database_selection_dialog.ui'
+##
+## Created by: Qt User Interface Compiler version 6.9.1
+##
+## WARNING! All changes made in this file will be lost when recompiling UI file!
+################################################################################
+
+from PySide6.QtCore import (QCoreApplication, QDate, QDateTime, QLocale,
+    QMetaObject, QObject, QPoint, QRect,
+    QSize, QTime, QUrl, Qt)
+from PySide6.QtGui import (QBrush, QColor, QConicalGradient, QCursor,
+    QFont, QFontDatabase, QGradient, QIcon,
+    QImage, QKeySequence, QLinearGradient, QPainter,
+    QPalette, QPixmap, QRadialGradient, QTransform)
+from PySide6.QtWidgets import (QAbstractButton, QApplication, QDialog, QDialogButtonBox,
+    QListWidget, QListWidgetItem, QSizePolicy, QVBoxLayout,
+    QWidget)
+
+class Ui_DatabaseSelectionDialog(object):
+    def setupUi(self, DatabaseSelectionDialog):
+        if not DatabaseSelectionDialog.objectName():
+            DatabaseSelectionDialog.setObjectName(u"DatabaseSelectionDialog")
+        self.verticalLayout = QVBoxLayout(DatabaseSelectionDialog)
+        self.verticalLayout.setObjectName(u"verticalLayout")
+        self.databaseList = QListWidget(DatabaseSelectionDialog)
+        self.databaseList.setObjectName(u"databaseList")
+
+        self.verticalLayout.addWidget(self.databaseList)
+
+        self.buttonBox = QDialogButtonBox(DatabaseSelectionDialog)
+        self.buttonBox.setObjectName(u"buttonBox")
+        self.buttonBox.setStandardButtons(QDialogButtonBox.Cancel|QDialogButtonBox.Ok)
+
+        self.verticalLayout.addWidget(self.buttonBox)
+
+
+        self.retranslateUi(DatabaseSelectionDialog)
+
+        QMetaObject.connectSlotsByName(DatabaseSelectionDialog)
+    # setupUi
+
+    def retranslateUi(self, DatabaseSelectionDialog):
+        DatabaseSelectionDialog.setWindowTitle(QCoreApplication.translate("DatabaseSelectionDialog", u"Datenbank ausw\u00e4hlen", None))
+    # retranslateUi
+

--- a/tests/test_database_selection_dialog.py
+++ b/tests/test_database_selection_dialog.py
@@ -1,0 +1,28 @@
+import sys
+from pathlib import Path
+import os
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+pytest.importorskip("PySide6")
+
+from PySide6.QtWidgets import QApplication
+from ui import database_selection_dialog as dlg_module
+
+
+def test_accept_returns_selection():
+    app = QApplication.instance() or QApplication([])  # noqa: F841 - keep reference
+    dlg = dlg_module.DatabaseSelectionDialog(["db1", "db2"])  # pragma: no cover - simple dialog
+    dlg.ui.databaseList.setCurrentRow(1)
+    dlg.accept()
+    assert dlg.get_selection() == "db2"
+
+
+def test_cancel_returns_none():
+    app = QApplication.instance() or QApplication([])  # noqa: F841 - keep reference
+    dlg = dlg_module.DatabaseSelectionDialog(["db1"])
+    dlg.ui.databaseList.setCurrentRow(0)
+    dlg.reject()
+    assert dlg.get_selection() is None


### PR DESCRIPTION
## Summary
- move database selection dialog to Qt Designer `.ui` file with generated Python wrapper
- instantiate `DatabaseSelectionDialogUi` to populate list and hook up buttons
- expose new generated UI

## Testing
- `python utils/generate_qt_artefacts.py --ui $(pwd)/src/ui/design/database_selection_dialog.ui`
- `pytest tests/test_database_selection_dialog.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ac3901b6b08322b195a9f76e78fc12