### PR TITLE
Refactor MySQL loading to use facade

### DIFF
--- a/src/backend/interface/mysql_interface.py
+++ b/src/backend/interface/mysql_interface.py
@@ -60,7 +60,8 @@ class MySQLInterface(DatabaseOperations):
             "host": self.params.get("host", "localhost"),
             "user": self.params.get("user"),
             "password": self.params.get("password"),
-            "database": db_to_connect # Pass None if not specified
+            "port": self.params.get("port", 3306),
+            "database": db_to_connect  # Pass None if not specified
         }
         print(f"Versuche Verbindung zu MySQL ({connect_args['host']}, DB: {db_to_connect or 'Server'})...")
 
@@ -158,7 +159,8 @@ class MySQLInterface(DatabaseOperations):
             temp_conn = mysql_connector_lib.connect(
                 host=self.params.get("host", "localhost"),
                 user=self.params.get("user"),
-                password=self.params.get("password")
+                password=self.params.get("password"),
+                port=self.params.get("port", 3306)
                 # No 'database' argument here
             )
             cursor = temp_conn.cursor()
@@ -197,7 +199,8 @@ class MySQLInterface(DatabaseOperations):
             temp_conn = mysql_connector_lib.connect(
                 host=self.params.get("host", "localhost"),
                 user=self.params.get("user"),
-                password=self.params.get("password")
+                password=self.params.get("password"),
+                port=self.params.get("port", 3306)
             )
             cursor = temp_conn.cursor()
             # Use backticks for safety
@@ -243,6 +246,7 @@ class MySQLInterface(DatabaseOperations):
                 host=self.params.get("host", "localhost"),
                 user=self.params.get("user"),
                 password=self.params.get("password"),
+                port=self.params.get("port", 3306),
             )
             cursor = temp_conn.cursor()
             if prefix:

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -24,7 +24,6 @@ from .status_bar import StatusBar
 from .new_market_dialog import NewMarketDialog
 from .database_settings_dialog import DatabaseSettingsDialog
 from .project_creation_service import ProjectCreationService
-from backend import SQLiteInterface, MySQLInterface
 
 
 class MainWindow(QMainWindow):
@@ -98,7 +97,6 @@ class MainWindow(QMainWindow):
         self.ui.action_restore_seller.triggered.connect(
             self.market_view.data_view.restore_changes)
 
-        self.ui.action_connect_db.triggered.connect(self.connect_to_db)
         self.ui.action_disconnect_db.triggered.connect(self.disconnect_from_db)
         self.ui.action_upload_data.triggered.connect(self.upload_data)
         self.ui.action_export_data.triggered.connect(self.export_data)
@@ -201,24 +199,6 @@ class MainWindow(QMainWindow):
                     self.market_view, market_loader_info["path"]
                 )
             elif market_loader_info["mode"] == "mysql":
-                try:
-                    server_if = MySQLInterface(
-                        host=market_loader_info["host"],
-                        port=market_loader_info["port"],
-                        user=market_loader_info["user"],
-                        password=market_loader_info["password"],
-                    )
-                    self.market_facade.connect_to_db(server_if)
-                    self.market_facade.status_info.emit(
-                        "INFO",
-                        f"Server verbunden: {market_loader_info['host']}:{market_loader_info['port']}",
-                    )
-                except Exception as exc:  # pragma: no cover - runtime path
-                    self.market_facade.status_info.emit(
-                        "ERROR", f"Verbindung fehlgeschlagen: {exc}"
-                    )
-                    self.market_facade.db_disconnected.emit()
-                    return
                 ret = self.market_facade.load_online_market(
                     self.market_view, market_loader_info
                 )
@@ -341,11 +321,6 @@ class MainWindow(QMainWindow):
             mch.set_database(host, port)
             mch.set_db_credentials(name, user)
             self.save_project()
-
-    @Slot()
-    def connect_to_db(self):
-        """Connect to the configured database via the facade."""
-        self.market_facade.connect_to_db(SQLiteInterface(database=":memory:"))
 
     @Slot()
     def disconnect_from_db(self):

--- a/tests/test_mysql_interface.py
+++ b/tests/test_mysql_interface.py
@@ -1,0 +1,22 @@
+import types
+from backend.interface import mysql_interface
+
+def test_connect_db_uses_port(monkeypatch):
+    called = {}
+
+    class DummyConn:
+        def is_connected(self):
+            return True
+
+    def dummy_connect(**kwargs):
+        called.update(kwargs)
+        return DummyConn()
+
+    dummy_module = types.SimpleNamespace(connect=dummy_connect, Error=Exception, errorcode=types.SimpleNamespace())
+    monkeypatch.setattr(mysql_interface, 'mysql_connector_lib', dummy_module)
+    monkeypatch.setattr(mysql_interface, 'MYSQL_AVAILABLE', True)
+
+    iface = mysql_interface.MySQLInterface(host='h', user='u', password='p', database='d', port=1234)
+    iface.connect_db()
+
+    assert called['port'] == 1234


### PR DESCRIPTION
## Summary
- Load MySQL-based market data via `MarketFacade` instead of `MainWindow`
- Drop direct `MySQLInterface` usage in the UI layer
- Remove unused `SQLiteInterface` import and connection logic from `MainWindow`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68acbc184b1883228dd8112d8add8d1c