### PR TITLE
Consolidate online market loading logic

### DIFF
--- a/src/backend/advanced_db_manager_thread.py
+++ b/src/backend/advanced_db_manager_thread.py
@@ -48,6 +48,11 @@ class AdvancedDBManagerThread(QThread):
         super().__init__(parent)
         self._db_interface = db_interface
         self.manager = AdvancedDBManager(self._db_interface)
+        # Ensure the manager and its internal QTimer live in this worker thread.
+        # Otherwise, starting the timer from :meth:`connect_to_db` would trigger
+        # "QObject::startTimer" warnings because the object would still belong
+        # to the main thread.
+        self.manager.moveToThread(self)
         self._tasks: "queue.Queue[Tuple[Callable[..., Any], tuple, dict]]" = queue.Queue()
         self._stop_event = threading.Event()
 

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -17,7 +17,6 @@ from .main_menu import MainMenu
 from .market import Market
 from .pdf_display import PdfDisplay
 from .market_loader_dialog import MarketLoaderDialog
-from .database_selection_dialog import DatabaseSelectionDialog
 from .output_window import OutputWindow
 from .generator_worker import GeneratorWorker
 from data import MarketFacade
@@ -202,58 +201,11 @@ class MainWindow(QMainWindow):
                 self.market_view, market_loader_info["path"]
             )
         elif market_loader_info["mode"] == "mysql":
-            if not self.market_facade.connect_to_mysql_server(
-                market_loader_info["host"],
-                market_loader_info["port"],
-                market_loader_info["user"],
-                market_loader_info["password"],
-            ):
-                return
-
-            databases = self.market_facade.list_databases()
-            if not databases:
-                self.market_facade.db_disconnected.emit()
-                return
-
-            selected_db = None
-            db_name = market_loader_info.get("database")
-            if db_name:
-                matches = [db for db in databases if db.startswith(db_name)]
-                if len(matches) == 1 and matches[0] == db_name:
-                    selected_db = matches[0]
-                elif matches:
-                    dlg = DatabaseSelectionDialog(matches, self)
-                    if dlg.exec() != QDialog.DialogCode.Accepted:
-                        self.market_facade.db_disconnected.emit()
-                        return
-                    selected_db = dlg.get_selection()
-                    if not selected_db:
-                        self.market_facade.db_disconnected.emit()
-                        return
-                else:
-                    self.market_facade.status_info.emit(
-                        "ERROR", "Keine passende Datenbank gefunden"
-                    )
-                    self.market_facade.db_disconnected.emit()
-                    return
-            else:
-                dlg = DatabaseSelectionDialog(databases, self)
-                if dlg.exec() != QDialog.DialogCode.Accepted:
-                    self.market_facade.db_disconnected.emit()
-                    return
-                selected_db = dlg.get_selection()
-                if not selected_db:
-                    self.market_facade.db_disconnected.emit()
-                    return
-
-            market_loader_info["database"] = selected_db
-
             ret = self.market_facade.load_online_market(
-                self.market_view, market_loader_info
+                self.market_view, market_loader_info, self
             )
         else:
             return
-
         if ret:
             self.open_view("Market")
 


### PR DESCRIPTION
## Summary
- Move MySQL connection and database selection into `MarketFacade.load_online_market` to avoid duplication.
- Simplify `MainWindow.open_market_view` to delegate online market loading to the facade.

## Testing
- `QT_QPA_PLATFORM=offscreen pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b1869ea8808322a7d7893bdfbbffbe