### PR TITLE
Use persistent DB connection for export

### DIFF
--- a/src/data/market_facade.py
+++ b/src/data/market_facade.py
@@ -118,6 +118,52 @@ class MarketFacade(QObject, metaclass=SingletonMeta):
 
         return databases
 
+    def select_database(self, database: str) -> bool:
+        """Select the active database on an existing connection.
+
+        Parameters
+        ----------
+        database:
+            Name of the database to select.
+
+        Returns
+        -------
+        bool
+            ``True`` if the database was selected successfully, ``False`` otherwise.
+        """
+
+        if self._db_thread is None:
+            self.status_info.emit("ERROR", "Keine Serververbindung vorhanden")
+            return False
+
+        success = False
+        loop = QEventLoop()
+
+        def _handle_finished(result: object) -> None:  # pragma: no cover - Qt slot
+            nonlocal success
+            success = bool(result)
+            loop.quit()
+
+        def _handle_error(exc: Exception) -> None:  # pragma: no cover - Qt slot
+            self.status_info.emit("ERROR", f"Datenbank konnte nicht gewählt werden: {exc}")
+            self.db_disconnected.emit()
+            loop.quit()
+
+        db_thread = self._db_thread
+        db_thread.task_finished.connect(_handle_finished)
+        db_thread.task_error.connect(_handle_error)
+
+        def _task(mgr):
+            mgr.disconnect_from_db()
+            return mgr.connect_to_db(database)
+
+        db_thread.add_task(_task)
+        loop.exec()
+        db_thread.task_finished.disconnect(_handle_finished)
+        db_thread.task_error.disconnect(_handle_error)
+
+        return success
+
     def download_market_export(
         self, info: dict, output_path: str, on_finished: Callable[[bool], None]
     ) -> bool:
@@ -150,41 +196,50 @@ class MarketFacade(QObject, metaclass=SingletonMeta):
             on_finished(False)
             return False
 
-        try:
-            mysql_if = MySQLInterface(
-                host=host, user=user, password=password, database=database, port=port
-            )
-            db_thread = AdvancedDBManagerThread(mysql_if)
-            self._db_thread = db_thread
+        db_thread = self._db_thread
+        temp_thread = False
 
-            def _cleanup() -> None:  # pragma: no cover - Qt slot
+        if db_thread is None:
+            try:
+                mysql_if = MySQLInterface(
+                    host=host, user=user, password=password, database=database, port=port
+                )
+                db_thread = AdvancedDBManagerThread(mysql_if)
+                self._db_thread = db_thread
+                db_thread.connected.connect(self.db_connected)
+                db_thread.disconnected.connect(self.db_disconnected)
+                db_thread.connecting.connect(self.db_connecting)
+                db_thread.start()
+                temp_thread = True
+            except Exception as e:  # pragma: no cover - error path
+                self.status_info.emit(
+                    "ERROR", f"Fehler beim Starten des DB-Threads: {e}"
+                )
+                on_finished(False)
+                return False
+
+        def _cleanup() -> None:  # pragma: no cover - Qt slot
+            if temp_thread:
                 db_thread.stop()
                 self._db_thread = None
-                db_thread.task_finished.disconnect(_handle_finished)
-                db_thread.task_error.disconnect(_handle_error)
+            db_thread.task_finished.disconnect(_handle_finished)
+            db_thread.task_error.disconnect(_handle_error)
 
-            def _handle_finished(_result: object) -> None:  # pragma: no cover - Qt slot
-                _cleanup()
-                on_finished(True)
+        def _handle_finished(_result: object) -> None:  # pragma: no cover - Qt slot
+            _cleanup()
+            on_finished(True)
 
-            def _handle_error(exc: Exception) -> None:  # pragma: no cover - Qt slot
-                self.status_info.emit(
-                    "ERROR", f"Fehler beim Laden der Datenbank: {exc}"
-                )
-                _cleanup()
-                on_finished(False)
-
-            db_thread.task_finished.connect(_handle_finished)
-            db_thread.task_error.connect(_handle_error)
-            db_thread.start()
-            db_thread.add_task(lambda m: m.export_to_custom_json(output_path))
-            return True
-        except Exception as e:  # pragma: no cover - error path
+        def _handle_error(exc: Exception) -> None:  # pragma: no cover - Qt slot
             self.status_info.emit(
-                "ERROR", f"Fehler beim Starten des DB-Threads: {e}"
+                "ERROR", f"Fehler beim Laden der Datenbank: {exc}"
             )
+            _cleanup()
             on_finished(False)
-            return False
+
+        db_thread.task_finished.connect(_handle_finished)
+        db_thread.task_error.connect(_handle_error)
+        db_thread.add_task(lambda m: m.export_to_custom_json(output_path))
+        return True
 
     def load_online_market(self, market, info: dict) -> bool:
         """Load market data from a MySQL database.

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -238,8 +238,10 @@ class MainWindow(QMainWindow):
                     return
                 selected_db = dlg.get_selection()
 
-            self.market_facade.disconnect_from_db()
             if not selected_db:
+                self.market_facade.db_disconnected.emit()
+                return
+            if not self.market_facade.select_database(selected_db):
                 self.market_facade.db_disconnected.emit()
                 return
             info["database"] = selected_db


### PR DESCRIPTION
## Summary
- avoid disconnecting after listing MySQL databases
- allow selecting a database on existing connection
- reuse open connection for export instead of creating new temporary connections

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b22596cc948322a5a04214e975c370