### PR TITLE
Add database selection and reuse DB thread

### DIFF
--- a/src/data/market_facade.py
+++ b/src/data/market_facade.py
@@ -56,6 +56,12 @@ class MarketFacade(QObject, metaclass=SingletonMeta):
             ``False`` otherwise.
         """
 
+        if self._db_thread is not None:
+            self.status_info.emit(
+                "INFO", f"Server bereits verbunden: {host}:{port}"
+            )
+            return True
+
         try:
             server_if = MySQLInterface(
                 host=host, port=port, user=user, password=password
@@ -118,6 +124,27 @@ class MarketFacade(QObject, metaclass=SingletonMeta):
 
         return databases
 
+    def select_database(self, name: str) -> bool:
+        """Select a database on the connected server.
+
+        Parameters
+        ----------
+        name:
+            Name of the database to select.
+
+        Returns
+        -------
+        bool
+            ``True`` if the task was queued successfully, ``False`` otherwise.
+        """
+
+        if self._db_thread is None:
+            self.status_info.emit("ERROR", "Keine Serververbindung")
+            return False
+
+        self._db_thread.add_task(lambda m: m.connect_to_db(name))
+        return True
+
     def download_market_export(
         self, info: dict, output_path: str, on_finished: Callable[[bool], None]
     ) -> bool:
@@ -151,32 +178,37 @@ class MarketFacade(QObject, metaclass=SingletonMeta):
             return False
 
         try:
-            mysql_if = MySQLInterface(
-                host=host, user=user, password=password, database=database, port=port
-            )
-            db_thread = AdvancedDBManagerThread(mysql_if)
-            self._db_thread = db_thread
+            if self._db_thread is None:
+                if not self.connect_to_mysql_server(host, port, user, password):
+                    on_finished(False)
+                    return False
 
-            def _cleanup() -> None:  # pragma: no cover - Qt slot
-                db_thread.stop()
-                self._db_thread = None
-                db_thread.task_finished.disconnect(_handle_finished)
-                db_thread.task_error.disconnect(_handle_error)
+            if not self.select_database(database):
+                on_finished(False)
+                return False
+
+            db_thread = self._db_thread
+            pending = True
 
             def _handle_finished(_result: object) -> None:  # pragma: no cover - Qt slot
-                _cleanup()
+                nonlocal pending
+                if pending:
+                    pending = False
+                    return
+                db_thread.task_finished.disconnect(_handle_finished)
+                db_thread.task_error.disconnect(_handle_error)
                 on_finished(True)
 
             def _handle_error(exc: Exception) -> None:  # pragma: no cover - Qt slot
                 self.status_info.emit(
                     "ERROR", f"Fehler beim Laden der Datenbank: {exc}"
                 )
-                _cleanup()
+                db_thread.task_finished.disconnect(_handle_finished)
+                db_thread.task_error.disconnect(_handle_error)
                 on_finished(False)
 
             db_thread.task_finished.connect(_handle_finished)
             db_thread.task_error.connect(_handle_error)
-            db_thread.start()
             db_thread.add_task(lambda m: m.export_to_custom_json(output_path))
             return True
         except Exception as e:  # pragma: no cover - error path

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,179 @@
+import sys
+import types
+
+# Global PySide6 stubs to avoid ImportErrors when Qt is missing
+qtcore = types.ModuleType("PySide6.QtCore")
+qtwidgets = types.ModuleType("PySide6.QtWidgets")
+qtgui = types.ModuleType("PySide6.QtGui")
+qtcharts = types.ModuleType("PySide6.QtCharts")
+qtpdf = types.ModuleType("PySide6.QtPdf")
+
+
+class QObject:  # pragma: no cover - simple stub
+    pass
+
+
+class Signal:  # pragma: no cover - simple stub
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def connect(self, *args, **kwargs):
+        pass
+
+    def emit(self, *args, **kwargs):
+        pass
+
+
+def Slot(*args, **kwargs):  # pragma: no cover - simple stub
+    def decorator(func):
+        return func
+
+    return decorator
+
+
+class QThread:  # pragma: no cover - simple stub
+    def start(self):
+        pass
+
+    def wait(self):
+        pass
+
+
+class QEventLoop:  # pragma: no cover - simple stub
+    def exec(self):
+        pass
+
+    def quit(self):
+        pass
+
+
+class QCoreApplication:  # pragma: no cover - simple stub
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def exec(self):  # pragma: no cover - simple stub
+        return 0
+
+
+class QDate:  # pragma: no cover - simple stub
+    pass
+
+
+class QDateTime:  # pragma: no cover - simple stub
+    pass
+
+
+class QLocale:  # pragma: no cover - simple stub
+    pass
+
+
+class QTimer:  # pragma: no cover - simple stub
+    def start(self):
+        pass
+
+    def stop(self):
+        pass
+
+
+class _Qt:  # pragma: no cover - simple stub
+    transparent = 0
+
+    def __getattr__(self, name):  # pragma: no cover - simple stub
+        return 0
+
+
+Qt = _Qt()
+
+
+class QMetaObject:  # pragma: no cover - simple stub
+    pass
+
+
+class QFileDialog:  # pragma: no cover - simple stub
+    pass
+
+
+class QApplication:  # pragma: no cover - simple stub
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def exec(self):  # pragma: no cover - simple stub
+        return 0
+
+
+class QWidget:  # pragma: no cover - simple stub
+    pass
+
+
+class QDialog:  # pragma: no cover - simple stub
+    pass
+
+
+class QMainWindow:  # pragma: no cover - simple stub
+    pass
+
+
+class QMessageBox:  # pragma: no cover - simple stub
+    pass
+
+
+class QFont:  # pragma: no cover - simple stub
+    Bold = 0
+
+    def __init__(self, *args, **kwargs):
+        pass
+
+
+qtcore.QObject = QObject
+qtcore.Signal = Signal
+qtcore.Slot = Slot
+qtcore.QThread = QThread
+qtcore.QEventLoop = QEventLoop
+qtcore.QCoreApplication = QCoreApplication
+qtcore.QDate = QDate
+qtcore.QDateTime = QDateTime
+qtcore.QLocale = QLocale
+qtcore.QTimer = QTimer
+qtcore.Qt = Qt
+qtcore.QMetaObject = QMetaObject
+
+qtwidgets.QApplication = QApplication
+qtwidgets.QWidget = QWidget
+qtwidgets.QDialog = QDialog
+qtwidgets.QMainWindow = QMainWindow
+qtwidgets.QMessageBox = QMessageBox
+qtwidgets.QFileDialog = QFileDialog
+qtgui.QFont = QFont
+
+pyside6 = types.ModuleType("PySide6")
+pyside6.QtCore = qtcore
+pyside6.QtWidgets = qtwidgets
+pyside6.QtGui = qtgui
+pyside6.QtCharts = qtcharts
+pyside6.QtPdf = qtpdf
+
+sys.modules.setdefault("PySide6", pyside6)
+sys.modules.setdefault("PySide6.QtCore", qtcore)
+sys.modules.setdefault("PySide6.QtWidgets", qtwidgets)
+sys.modules.setdefault("PySide6.QtGui", qtgui)
+sys.modules.setdefault("PySide6.QtCharts", qtcharts)
+sys.modules.setdefault("PySide6.QtPdf", qtpdf)
+
+
+def _qtcore_getattr(name):  # pragma: no cover - simple stub
+    cls = type(name, (), {"__init__": lambda self, *a, **k: None})
+    setattr(qtcore, name, cls)
+    return cls
+
+
+def _qtwidgets_getattr(name):  # pragma: no cover - simple stub
+    cls = type(name, (), {"__init__": lambda self, *a, **k: None})
+    setattr(qtwidgets, name, cls)
+    return cls
+
+
+qtcore.__getattr__ = _qtcore_getattr
+qtwidgets.__getattr__ = _qtwidgets_getattr
+qtgui.__getattr__ = _qtwidgets_getattr
+qtcharts.__getattr__ = _qtwidgets_getattr
+qtpdf.__getattr__ = _qtwidgets_getattr

--- a/tests/test_market_facade_db_thread.py
+++ b/tests/test_market_facade_db_thread.py
@@ -1,0 +1,191 @@
+import importlib
+import importlib
+import sys
+from pathlib import Path
+import types
+
+import pytest
+
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / 'src'))
+
+
+@pytest.fixture
+def facade_class(monkeypatch):
+    """Provide ``MarketFacade`` with minimal Qt stubs."""
+
+    qtcore = types.ModuleType('PySide6.QtCore')
+
+    class QObject:  # pragma: no cover - simple stub
+        pass
+
+    class Signal:  # pragma: no cover - simple stub
+        def __init__(self, *args, **kwargs):
+            self._callbacks = []
+
+        def connect(self, callback):
+            self._callbacks.append(callback)
+
+        def disconnect(self, callback):
+            if callback in self._callbacks:
+                self._callbacks.remove(callback)
+
+        def emit(self, *args, **kwargs):
+            for cb in list(self._callbacks):
+                cb(*args, **kwargs)
+
+    def Slot(*args, **kwargs):  # pragma: no cover - simple stub
+        def decorator(func):
+            return func
+
+        return decorator
+
+    class QThread:  # pragma: no cover - simple stub
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def start(self):
+            pass
+
+        def wait(self):
+            pass
+
+    class QEventLoop:  # pragma: no cover - simple stub
+        def exec(self):
+            pass
+
+        def quit(self):
+            pass
+
+    qtcore.QObject = QObject
+    qtcore.Signal = Signal
+    qtcore.Slot = Slot
+    qtcore.QThread = QThread
+    qtcore.QEventLoop = QEventLoop
+
+    pyside6 = types.ModuleType('PySide6')
+    pyside6.QtCore = qtcore
+
+    monkeypatch.setitem(sys.modules, 'PySide6', pyside6)
+    monkeypatch.setitem(sys.modules, 'PySide6.QtCore', qtcore)
+
+    module = importlib.import_module('data.market_facade')
+    importlib.reload(module)
+    return module.MarketFacade
+
+
+class DummySignal:
+    def __init__(self):
+        self._callbacks = []
+
+    def connect(self, callback):  # pragma: no cover - simple stub
+        self._callbacks.append(callback)
+
+    def disconnect(self, callback):  # pragma: no cover - simple stub
+        if callback in self._callbacks:
+            self._callbacks.remove(callback)
+
+    def emit(self, *args):  # pragma: no cover - simple stub
+        for cb in list(self._callbacks):
+            cb(*args)
+
+
+class DummyManager:
+    def __init__(self):
+        self.selected_db = None
+        self.export_path = None
+
+    def connect_to_db(self, name=None):  # pragma: no cover - simple stub
+        self.selected_db = name
+
+    def export_to_custom_json(self, path):  # pragma: no cover - simple stub
+        self.export_path = path
+        Path(path).write_text('[]', encoding='utf-8')
+
+
+class DummyThread:
+    def __init__(self, manager):
+        self.manager = manager
+        self.task_finished = DummySignal()
+        self.task_error = DummySignal()
+
+    def add_task(self, func, *args, **kwargs):  # pragma: no cover - simple stub
+        try:
+            result = func(self.manager, *args, **kwargs)
+            self.task_finished.emit(result)
+        except Exception as exc:  # pragma: no cover - simple stub
+            self.task_error.emit(exc)
+
+    def list_databases(self, prefix=None):  # pragma: no cover - simple stub
+        self.add_task(lambda _m: [])
+
+    def start(self):  # pragma: no cover - simple stub
+        pass
+
+    def stop(self):  # pragma: no cover - simple stub
+        pass
+
+
+def test_select_database_queues_task(facade_class):
+    facade = facade_class()
+    manager = DummyManager()
+    facade._db_thread = DummyThread(manager)
+
+    assert facade.select_database('foo') is True
+    assert manager.selected_db == 'foo'
+
+
+def test_download_market_export_reuses_thread(tmp_path, monkeypatch, facade_class):
+    facade = facade_class()
+    manager = DummyManager()
+    thread = DummyThread(manager)
+    facade._db_thread = thread
+
+    connect_calls = []
+
+    def fake_connect(self, *args, **kwargs):  # pragma: no cover - simple stub
+        connect_calls.append(True)
+        return True
+
+    monkeypatch.setattr(facade_class, 'connect_to_mysql_server', fake_connect)
+
+    info = {'database': 'bar'}
+    out_file = tmp_path / 'out.json'
+    result = []
+
+    assert facade.download_market_export(info, str(out_file), result.append)
+    assert result == [True]
+    assert manager.selected_db == 'bar'
+    assert manager.export_path == str(out_file)
+    assert connect_calls == []
+    assert facade._db_thread is thread
+
+
+def test_connect_to_mysql_server_only_once(monkeypatch, facade_class):
+    class DummyMySQLInterface:
+        calls = 0
+
+        def __init__(self, host, port, user, password):
+            DummyMySQLInterface.calls += 1
+
+    monkeypatch.setitem(sys.modules, 'backend.MySQLInterface', DummyMySQLInterface)
+
+    connect_calls = []
+
+    def dummy_connect(self, db_interface):  # pragma: no cover - simple stub
+        connect_calls.append(db_interface)
+        self._db_thread = object()
+
+    monkeypatch.setattr(facade_class, 'connect_to_db', dummy_connect)
+
+    facade = facade_class()
+    assert facade.connect_to_mysql_server('h', 1, 'u', 'p') is True
+    first_thread = facade._db_thread
+    assert DummyMySQLInterface.calls == 1
+    assert len(connect_calls) == 1
+
+    assert facade.connect_to_mysql_server('h2', 2, 'u2', 'p2') is True
+    assert facade._db_thread is first_thread
+    assert DummyMySQLInterface.calls == 1
+    assert len(connect_calls) == 1
+


### PR DESCRIPTION
## Summary
- Ensure MySQL server connection is created only once and reused
- Add `select_database` and reuse existing DB thread for exports
- Test facade thread handling with lightweight Qt stubs

## Testing
- `pytest tests -q` *(fails: Cannot create a consistent method resolution order for bases type, ABCMeta)*

------
https://chatgpt.com/codex/tasks/task_e_68b22596bf5c8322adf5b6f058b09f0a